### PR TITLE
Upgrade sequence dependencies to 2.1.3 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,7 @@ VITE_GOOGLE_CLIENT_ID_DEV=970987756660-35a6tc48hvi8cev9cnknp0iugv9poa23.apps.goo
 # Get this from Apple Developer Portal
 # Or use these for development purposes only, NOTICE: will only work on localhost.direct:443
 # Setting it empty will disable Apple login.
-VITE_APPLE_CLIENT_ID=com.horizon.sequence.waas
+VITE_APPLE_CLIENT_ID=com.horizon.sequence.demo-embedded-wallet-auth
 
 # The Sequence Project Access Key, used for auth with Sequence API
 VITE_SEQUENCE_PROJECT_ACCESS_KEY=AQAAAAAAAEGvyZiWA9FMslYeG_yayXaHnSI

--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
     "postinstall": "(cp -n .env.example .env) || echo already exists"
   },
   "dependencies": {
-    "0xsequence": "2.1.3",
+    "0xsequence": "2.2.4",
+    "@0xsequence/indexer": "2.2.4",
+    "@0xsequence/network": "2.2.4",
+    "@0xsequence/waas": "2.2.4",
     "@0xsequence/design-system": "1.7.8",
-    "@0xsequence/indexer": "2.1.3",
-    "@0xsequence/network": "2.1.3",
-    "@0xsequence/waas": "2.1.3",
     "@react-oauth/google": "^0.12.1",
     "@stytch/react": "^19.1.0",
     "@stytch/vanilla-js": "^5.5.0",

--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
     "postinstall": "(cp -n .env.example .env) || echo already exists"
   },
   "dependencies": {
-    "0xsequence": "2.0.17",
+    "0xsequence": "2.1.3",
     "@0xsequence/design-system": "1.7.8",
-    "@0xsequence/indexer": "2.0.17",
-    "@0xsequence/network": "2.0.17",
-    "@0xsequence/waas": "2.0.17",
+    "@0xsequence/indexer": "2.1.3",
+    "@0xsequence/network": "2.1.3",
+    "@0xsequence/waas": "2.1.3",
     "@react-oauth/google": "^0.12.1",
     "@stytch/react": "^19.1.0",
     "@stytch/vanilla-js": "^5.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,20 +9,20 @@ importers:
   .:
     dependencies:
       0xsequence:
-        specifier: 2.1.3
-        version: 2.1.3(ethers@6.13.3)
+        specifier: 2.2.4
+        version: 2.2.4(ethers@6.13.3)
       '@0xsequence/design-system':
         specifier: 1.7.8
         version: 1.7.8(@types/react-dom@18.3.0)(@types/react@18.3.11)(framer-motion@11.11.7(@emotion/is-prop-valid@1.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@0xsequence/indexer':
-        specifier: 2.1.3
-        version: 2.1.3
+        specifier: 2.2.4
+        version: 2.2.4
       '@0xsequence/network':
-        specifier: 2.1.3
-        version: 2.1.3(ethers@6.13.3)
+        specifier: 2.2.4
+        version: 2.2.4(ethers@6.13.3)
       '@0xsequence/waas':
-        specifier: 2.1.3
-        version: 2.1.3(ethers@6.13.3)
+        specifier: 2.2.4
+        version: 2.2.4(ethers@6.13.3)
       '@react-oauth/google':
         specifier: ^0.12.1
         version: 0.12.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -123,29 +123,29 @@ importers:
 
 packages:
 
-  0xsequence@2.1.3:
-    resolution: {integrity: sha512-tHgY4OeHLw6anmplV1pQ8qwoZrKs14ctu3VRU7T3KlAqXcS9S54QhTL5UAW18AvM+ETc8DZM1+poFM5au4+/Iw==}
+  0xsequence@2.2.4:
+    resolution: {integrity: sha512-dTZnOlBccJpNo5mhJEMAwhR1YvTlDKKSwSwOwzpreHWHJP+zrcs+dKQyVkZFvFyJUB8gEe/p3J4TASFAuBKgpg==}
     peerDependencies:
       ethers: '>=6'
 
-  '@0xsequence/abi@2.1.3':
-    resolution: {integrity: sha512-koeVkNUc/xm4yiAA1fC89r6oe6gQHwsVNkH6bTLicw1Wl9zWxqcv3GVtdFcmdablBumM4vAySHejxSEuM4S8TA==}
+  '@0xsequence/abi@2.2.4':
+    resolution: {integrity: sha512-kCNYbhk+15QB5lvQ1sh+CV2vspQURmJDbpnCUeS005DDQ4EgPdiUZ/L4ohAQWWvzGFbamPYMnLPJweaWC5jGYw==}
 
-  '@0xsequence/account@2.1.3':
-    resolution: {integrity: sha512-6VPdLWVUv3DAEqwEEx3eTHOmaUDcCAqtf+9aZGC85kW+LUogdGVHB1QUngjJeMnGlQKSTMrL/Nnm3pEGi7eMAg==}
+  '@0xsequence/account@2.2.4':
+    resolution: {integrity: sha512-bOqT//7m6i27cOXgAdYqcupoWdauwepS3QXi2nSB5vQwQnVENeGbmmQk7B4hTpfc7h7xBfWdcmrWB/ps1jj90A==}
     peerDependencies:
       ethers: '>=6'
 
-  '@0xsequence/api@2.1.3':
-    resolution: {integrity: sha512-UTy9fnEsWi6MQjAKdZye03eofofmTV1uzodsNQA5r7AJCyFNN9x979M6k5GGG90aam6vol0cnNMuei063xA7Og==}
+  '@0xsequence/api@2.2.4':
+    resolution: {integrity: sha512-Sr2jONWgfxQAmIbe1dRneojWYDQ8lcWNOalWGUajTfkyokbaivhfpAYr63v4bLKMJ4i6ncRpi3zkcT712dqTAw==}
 
-  '@0xsequence/auth@2.1.3':
-    resolution: {integrity: sha512-ogG/5EhVbJg0dzRKtbeqAJPtkNXl+VNpllKq19WxyacsFR/jWquFXKjCJ2S+xne8TckW28i3QsmUZujwGoJYsw==}
+  '@0xsequence/auth@2.2.4':
+    resolution: {integrity: sha512-boQAmPRwDm3aFYFRhlJUnIZZCdHo836EuEDkzdOOA+BjAoLVSZzrUG0DnxeemyRSP91zO6Kz3l7FRY9ep1ziuw==}
     peerDependencies:
       ethers: '>=6'
 
-  '@0xsequence/core@2.1.3':
-    resolution: {integrity: sha512-GA5dl0tEPNywQpqKjhX9LiKJqFwc8WFnN6WD8QeFL57lQS6akMyZUHw9miCLeGTyzaMX0SiFTeQM/ztSbMEXdQ==}
+  '@0xsequence/core@2.2.4':
+    resolution: {integrity: sha512-nJUxjTU225h6YG0MkBwRVmxzw16wuVDo+7Om6s7Pfg8Fd3CYWMIRE8rBiGTl9GRw0L6HJI+TDr9jszpUqKr38w==}
     peerDependencies:
       ethers: '>=6'
 
@@ -161,64 +161,64 @@ packages:
     peerDependencies:
       ethers: '>=6'
 
-  '@0xsequence/guard@2.1.3':
-    resolution: {integrity: sha512-urDqFiBM/S8AUfgXs5Nb95M2YyA7kXJQm4UCVMhQHtTOQz+L3XXJRfP2d68FdPkQvDkg5hfjJl1xVIq3ZsPn+g==}
+  '@0xsequence/guard@2.2.4':
+    resolution: {integrity: sha512-8pwdy1x5PhVSaI2ZdiOUPGOhe3I4AG6iHwZIAcMVnJUEM4KOhxiq+MYqa8voG7nW2SEwzOkpkPANgXBHcki6kw==}
     peerDependencies:
       ethers: '>=6'
 
-  '@0xsequence/indexer@2.1.3':
-    resolution: {integrity: sha512-49QUo3TgecAaqNNi0n0/1AGV6c1wfNAPsYOCFFhotNJvxgVYfEBseSPx/bFN1QCYDX2v5fdMQmsWJ1iiNFKdFw==}
+  '@0xsequence/indexer@2.2.4':
+    resolution: {integrity: sha512-6Ld6KpZvXOwpexy0ksgzkvSKItbkE6LrJI1uGbNgUlBZRW/fe1q0P9HBOhiHDv7uIvWeUDSfbyaxmuyAWq47QQ==}
 
-  '@0xsequence/metadata@2.1.3':
-    resolution: {integrity: sha512-YiCsledPwUNUyqTgga8VtOqQs3JNIxiEDxZfmOdgxkbA0sU0J9c+WSxS7BXgWNAqUpkuDr8dJ0ZRJjciQ/bUYQ==}
+  '@0xsequence/metadata@2.2.4':
+    resolution: {integrity: sha512-w45aULum1XOgs9x8ZYVGYgJz36oQQXvR33fv3TJ1lM4FtE6miZJI8INLoeOCdawywbjC78TffX20UzXtxc64Og==}
 
-  '@0xsequence/migration@2.1.3':
-    resolution: {integrity: sha512-pdYuq1QS+XaYugeyKAhjgyKiGEyZhXneIF3s5Gpy0ljPQ1l63ilpg0Vp4yihAfjau+y6y+TwQnRlM6LMynaUeg==}
+  '@0xsequence/migration@2.2.4':
+    resolution: {integrity: sha512-pFX2z52WO28gjhFy8IOVSkIXUuhE2CTWWSd+uFZWjBVod33rPP5ANfBHBfwEtNWIm8b6m6/Af8fyEnEP6ZDvrQ==}
     peerDependencies:
       ethers: '>=6'
 
-  '@0xsequence/network@2.1.3':
-    resolution: {integrity: sha512-Ghtvyf1qqxzzQYOaSpKDV6c5DyfmUpSoD5Lr+u2zswTCGvgK1tSic94lzKbu2WOmUAKbsXiVDvawoFaQyaMnGQ==}
+  '@0xsequence/network@2.2.4':
+    resolution: {integrity: sha512-NdrAe77CMgmrgBCmGqwaNphGrjBga+9tVJ9VrkGnhmH52eoNO/YiuxqSeodpilT7sR3CpeGRiQ3EzPjEomKGjw==}
     peerDependencies:
       ethers: '>=6'
 
-  '@0xsequence/provider@2.1.3':
-    resolution: {integrity: sha512-6bxisSso9fTY9YrR8yHnn8o9dQHgFDJi1R3iFc1HtNfasCxb0TwS9wblz/v3Us+943WqC9zUM12XZTMQZ+D55Q==}
+  '@0xsequence/provider@2.2.4':
+    resolution: {integrity: sha512-IqacrW38JiMmd8PyYNOauYq9k9AO+KigfCuRTGaVR38QPnRRjC6mFXXWX6IA/e8EqKAyNq7Hl1ayQCSMRom+AQ==}
     peerDependencies:
       ethers: '>=6'
 
-  '@0xsequence/relayer@2.1.3':
-    resolution: {integrity: sha512-8+WgbUT+ORvQwnHiegotHPLmxh/tl96VtUk0jDpEJX6iADaCpMshUqqvw4rUccV2G19jJQrhFP6DhEHTesLTBQ==}
+  '@0xsequence/relayer@2.2.4':
+    resolution: {integrity: sha512-Pj7m+b+egPRz6nk2ejisHwcbH04bFMb8e3BSbF37fiRsX/SjLNBCUvInYHKGhM7LFPdjSFaSgXpmHKOtHg9DjA==}
     peerDependencies:
       ethers: '>=6'
 
-  '@0xsequence/replacer@2.1.3':
-    resolution: {integrity: sha512-QSLaHPS9P7d31Ij0pZkt1SSz43VwSXeUbGkU6JVKx3HRU/u6H9KwExAJgwcs4B1zepMSq5mXG7Rz/Ri9XK1vCw==}
+  '@0xsequence/replacer@2.2.4':
+    resolution: {integrity: sha512-RhrR+oP9VV3CPcxSj+VagqmQYWi8h5kbs5//EeRqjQaXDpOtr2Jo9TbFwl+mACZvmwPskoLvNf4es/O8Q/fadw==}
     peerDependencies:
       ethers: '>=6'
 
-  '@0xsequence/sessions@2.1.3':
-    resolution: {integrity: sha512-9pm4tSZD9uji1sH3LyRXKY7v6dmAo37pSYo8SknAQkDYggFx40TSEE5jkmD0YuqN6eL2yyypCUynqGjoO4BkVA==}
+  '@0xsequence/sessions@2.2.4':
+    resolution: {integrity: sha512-D34XsUdyWXsrdYKzHlb6HtuV1CI+ciALG40MW4gkWXBiCmboStE4JGT6i26UjWvHfTwPMCLheALR2Pmm6vp6FQ==}
     peerDependencies:
       ethers: '>=6'
 
-  '@0xsequence/signhub@2.1.3':
-    resolution: {integrity: sha512-ZKLub0khcp4sN3IAZpat9MbnkLjq2M275hzv0XwDNOfHOcIESrSMWwNBqPg5ILqwR1o4JQxr0FyRoh9GG8gSjA==}
+  '@0xsequence/signhub@2.2.4':
+    resolution: {integrity: sha512-vP6PW/cAFfg4z5YHfj+KK4RC+daqMyMe5ZtUWt0YJddeycL2R+s4yD70gHo+rL2RjveGQxDaAO6cXlXqAzU8Og==}
     peerDependencies:
       ethers: '>=6'
 
-  '@0xsequence/utils@2.1.3':
-    resolution: {integrity: sha512-ZoHq6NpAbDFSXBkwaAxJYGQC8tSwKVSuwpyLQPdVkGWZhpkbifbML+RBEMe2x57biVj1c0EqF4K3xh0sYgQQEg==}
+  '@0xsequence/utils@2.2.4':
+    resolution: {integrity: sha512-dix1+HYwOY9DGjih0SmYdqR2WD0GeAo+2msLtuR6ILB2EqitkQ1v4kVYGvskimnwtqk3qjHdjC/e1YNK/ZDeog==}
     peerDependencies:
       ethers: '>=6'
 
-  '@0xsequence/waas@2.1.3':
-    resolution: {integrity: sha512-6qjqoyR3rVHrf5Vwfwu6+opPn8U9wOICfyC1Tv4NYPnrSkJF6LEaJFel0uJldxH0V0hxaYuy3h3SnKk4RfYjJw==}
+  '@0xsequence/waas@2.2.4':
+    resolution: {integrity: sha512-+uNMsU7pblVjLHUfhSt/GMjpXqNfyk1fIMfR19q+2BHCz+ybrSN65z1DqQAjPO2503F2i2ucR3fYdTG4T6PZ4w==}
     peerDependencies:
       ethers: '>=6'
 
-  '@0xsequence/wallet@2.1.3':
-    resolution: {integrity: sha512-oVd6LOfwdqzN8xgjd33odkGaVJ43D/NMHgLIKlpUlXnZa9d8c4fy5bA7Gujh9jWMI9qWjFP5kGImXgJ2b6/rZw==}
+  '@0xsequence/wallet@2.2.4':
+    resolution: {integrity: sha512-08Ph1Z3u4oOeVO8hxcEm8v4JBUewIdNiUZOMXcmlDOGQwzkKZPB90WdHJu3AJZG4rPbtgQaLbumwawekKodInA==}
     peerDependencies:
       ethers: '>=6'
 
@@ -242,104 +242,104 @@ packages:
   '@aws-crypto/util@5.2.0':
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
 
-  '@aws-sdk/client-cognito-identity-provider@3.668.0':
-    resolution: {integrity: sha512-RUdz8/jPxVtxjWT7kf5tK17xF83WgAY+AH71YQTdDkgVcj7idzDgBnu/zQ8wcWzPIaxX0usb39sJrGYEEUzfqA==}
-    engines: {node: '>=16.0.0'}
+  '@aws-sdk/client-cognito-identity-provider@3.723.0':
+    resolution: {integrity: sha512-5ki7Hf8wa85OpJT6ncT0rBRqYVyI3/ehstUn/Wy2HU91rzj7Z8fmYl+xO+VYoclLGwJIsJjrHfoHnIHcR4Y8vg==}
+    engines: {node: '>=18.0.0'}
 
-  '@aws-sdk/client-sso-oidc@3.668.0':
-    resolution: {integrity: sha512-b1Ib/92tcjOPXWYILfNuOOd2CYxmlr9lUfoZZBy/uwZCMObI6gtcpdUjfefyJohWfR+rk1WtsXi/sIXKxAhl/g==}
-    engines: {node: '>=16.0.0'}
+  '@aws-sdk/client-sso-oidc@3.723.0':
+    resolution: {integrity: sha512-9IH90m4bnHogBctVna2FnXaIGVORncfdxcqeEIovOxjIJJyHDmEAtA7B91dAM4sruddTbVzOYnqfPVst3odCbA==}
+    engines: {node: '>=18.0.0'}
     peerDependencies:
-      '@aws-sdk/client-sts': ^3.668.0
+      '@aws-sdk/client-sts': ^3.723.0
 
-  '@aws-sdk/client-sso@3.668.0':
-    resolution: {integrity: sha512-21YehzNmlaVbB6f4gAg9CTl6djExE7yxuWaRgbFugCtFhqZbmNhrh826B6cGvPVc5Dxx2rdMdI/SxTujtTJvag==}
-    engines: {node: '>=16.0.0'}
+  '@aws-sdk/client-sso@3.723.0':
+    resolution: {integrity: sha512-r1ddZDb8yPmdofX1gQ4m8oqKozgkgVONLlAuSprGObbyMy8bYt1Psxu+GjnwMmgVu3vlF069PHyW1ndrBiL1zA==}
+    engines: {node: '>=18.0.0'}
 
-  '@aws-sdk/client-sts@3.668.0':
-    resolution: {integrity: sha512-Ele3N6WveoMsF2mZpN/1tM0jsu7qOUXWX7RKV1U4Dhe0TMbW1KdVIXz1oirWlc0BxCels7HX+CS1N7gg1axhwg==}
-    engines: {node: '>=16.0.0'}
+  '@aws-sdk/client-sts@3.723.0':
+    resolution: {integrity: sha512-YyN8x4MI/jMb4LpHsLf+VYqvbColMK8aZeGWVk2fTFsmt8lpTYGaGC1yybSwGX42mZ4W8ucu8SAYSbUraJZEjA==}
+    engines: {node: '>=18.0.0'}
 
-  '@aws-sdk/core@3.667.0':
-    resolution: {integrity: sha512-pMcDVI7Tmdsc8R3sDv0Omj/4iRParGY+uJtAfF669WnZfDfaBQaix2Mq7+Mu08vdjqO9K3gicFvjk9S1VLmOKA==}
-    engines: {node: '>=16.0.0'}
+  '@aws-sdk/core@3.723.0':
+    resolution: {integrity: sha512-UraXNmvqj3vScSsTkjMwQkhei30BhXlW5WxX6JacMKVtl95c7z0qOXquTWeTalYkFfulfdirUhvSZrl+hcyqTw==}
+    engines: {node: '>=18.0.0'}
 
-  '@aws-sdk/credential-provider-env@3.667.0':
-    resolution: {integrity: sha512-zZbrkkaPc54WXm+QAnpuv0LPNfsts0HPPd+oCECGs7IQRaFsGj187cwvPg9RMWDFZqpm64MdBDoA8OQHsqzYCw==}
-    engines: {node: '>=16.0.0'}
+  '@aws-sdk/credential-provider-env@3.723.0':
+    resolution: {integrity: sha512-OuH2yULYUHTVDUotBoP/9AEUIJPn81GQ/YBtZLoo2QyezRJ2QiO/1epVtbJlhNZRwXrToLEDmQGA2QfC8c7pbA==}
+    engines: {node: '>=18.0.0'}
 
-  '@aws-sdk/credential-provider-http@3.667.0':
-    resolution: {integrity: sha512-sjtybFfERZWiqTY7fswBxKQLvUkiCucOWyqh3IaPo/4nE1PXRnaZCVG0+kRBPrYIxWqiVwytvZzMJy8sVZcG0A==}
-    engines: {node: '>=16.0.0'}
+  '@aws-sdk/credential-provider-http@3.723.0':
+    resolution: {integrity: sha512-DTsKC6xo/kz/ZSs1IcdbQMTgiYbpGTGEd83kngFc1bzmw7AmK92DBZKNZpumf8R/UfSpTcj9zzUUmrWz1kD0eQ==}
+    engines: {node: '>=18.0.0'}
 
-  '@aws-sdk/credential-provider-ini@3.668.0':
-    resolution: {integrity: sha512-npu7qBM8Qu+BzRh+omBvcnA9Hxt/5HZ6ifACtLUqqkPLhCgINSpVruVqDXJHinl6DrcmTL12XM+60VW90fq2uA==}
-    engines: {node: '>=16.0.0'}
+  '@aws-sdk/credential-provider-ini@3.723.0':
+    resolution: {integrity: sha512-fWRLksuSG851e7Iu+ltMrQTM7C/5iI9OkxAmCYblcCetAzjTRmMB2arku0Z83D8edIZEQtOJMt5oQ9KNg43pzg==}
+    engines: {node: '>=18.0.0'}
     peerDependencies:
-      '@aws-sdk/client-sts': ^3.668.0
+      '@aws-sdk/client-sts': ^3.723.0
 
-  '@aws-sdk/credential-provider-node@3.668.0':
-    resolution: {integrity: sha512-QHD6Y6xurKsHGQ7U2Az0UHu3R31mq7uokuMrWU9IIWB4Qa5t/Pkt4Od8TYXL/V4uAOthsLdchgfeCFSleOZMEA==}
-    engines: {node: '>=16.0.0'}
+  '@aws-sdk/credential-provider-node@3.723.0':
+    resolution: {integrity: sha512-OyLHt+aY+rkuRejigcxviS5RLUBcqbxhDTSNfP8dp9I+1SP610qRLpTIROvtKwXZssFcATpPfgikFtVYRrihXQ==}
+    engines: {node: '>=18.0.0'}
 
-  '@aws-sdk/credential-provider-process@3.667.0':
-    resolution: {integrity: sha512-HZHnvop32fKgsNHkdhVaul7UzQ25sEc0j9yqA4bjhtbk0ECl42kj3f1pJ+ZU/YD9ut8lMJs/vVqiOdNThVdeBw==}
-    engines: {node: '>=16.0.0'}
+  '@aws-sdk/credential-provider-process@3.723.0':
+    resolution: {integrity: sha512-fgupvUjz1+jeoCBA7GMv0L6xEk92IN6VdF4YcFhsgRHlHvNgm7ayaoKQg7pz2JAAhG/3jPX6fp0ASNy+xOhmPA==}
+    engines: {node: '>=18.0.0'}
 
-  '@aws-sdk/credential-provider-sso@3.668.0':
-    resolution: {integrity: sha512-cO14tsL7Lmyq4HfRHBBjEmcBDhlXv4eVgY8DQ9e/ujPFU+b99xiZiV80JSkJ8Kz99+woFl6pFo9PYp36YaI+Pw==}
-    engines: {node: '>=16.0.0'}
+  '@aws-sdk/credential-provider-sso@3.723.0':
+    resolution: {integrity: sha512-laCnxrk0pgUegU+ib6rj1/Uv51wei+cH8crvBJddybc8EDn7Qht61tCvBwf3o33qUDC+ZWZZewlpSebf+J+tBw==}
+    engines: {node: '>=18.0.0'}
 
-  '@aws-sdk/credential-provider-web-identity@3.667.0':
-    resolution: {integrity: sha512-t8CFlZMD/1p/8Cli3rvRiTJpjr/8BO64gw166AHgFZYSN2h95L2l1tcW0jpsc3PprA32nLg1iQVKYt4WGM4ugw==}
-    engines: {node: '>=16.0.0'}
+  '@aws-sdk/credential-provider-web-identity@3.723.0':
+    resolution: {integrity: sha512-tl7pojbFbr3qLcOE6xWaNCf1zEfZrIdSJtOPeSXfV/thFMMAvIjgf3YN6Zo1a6cxGee8zrV/C8PgOH33n+Ev/A==}
+    engines: {node: '>=18.0.0'}
     peerDependencies:
-      '@aws-sdk/client-sts': ^3.667.0
+      '@aws-sdk/client-sts': ^3.723.0
 
-  '@aws-sdk/middleware-host-header@3.667.0':
-    resolution: {integrity: sha512-Z7fIAMQnPegs7JjAQvlOeWXwpMRfegh5eCoIP6VLJIeR6DLfYKbP35JBtt98R6DXslrN2RsbTogjbxPEDQfw1w==}
-    engines: {node: '>=16.0.0'}
+  '@aws-sdk/middleware-host-header@3.723.0':
+    resolution: {integrity: sha512-LLVzLvk299pd7v4jN9yOSaWDZDfH0SnBPb6q+FDPaOCMGBY8kuwQso7e/ozIKSmZHRMGO3IZrflasHM+rI+2YQ==}
+    engines: {node: '>=18.0.0'}
 
-  '@aws-sdk/middleware-logger@3.667.0':
-    resolution: {integrity: sha512-PtTRNpNm/5c746jRgZCNg4X9xEJIwggkGJrF0GP9AB1ANg4pc/sF2Fvn1NtqPe9wtQ2stunJprnm5WkCHN7QiA==}
-    engines: {node: '>=16.0.0'}
+  '@aws-sdk/middleware-logger@3.723.0':
+    resolution: {integrity: sha512-chASQfDG5NJ8s5smydOEnNK7N0gDMyuPbx7dYYcm1t/PKtnVfvWF+DHCTrRC2Ej76gLJVCVizlAJKM8v8Kg3cg==}
+    engines: {node: '>=18.0.0'}
 
-  '@aws-sdk/middleware-recursion-detection@3.667.0':
-    resolution: {integrity: sha512-U5glWD3ehFohzpUpopLtmqAlDurGWo2wRGPNgi4SwhWU7UDt6LS7E/UvJjqC0CUrjlzOw+my2A+Ncf+fisMhxQ==}
-    engines: {node: '>=16.0.0'}
+  '@aws-sdk/middleware-recursion-detection@3.723.0':
+    resolution: {integrity: sha512-7usZMtoynT9/jxL/rkuDOFQ0C2mhXl4yCm67Rg7GNTstl67u7w5WN1aIRImMeztaKlw8ExjoTyo6WTs1Kceh7A==}
+    engines: {node: '>=18.0.0'}
 
-  '@aws-sdk/middleware-user-agent@3.668.0':
-    resolution: {integrity: sha512-6WSCeN9AZZM/bM1kXJluLPFptd6z+tMBEZw3J7m1EvJSBTKEoSHiBrZBjc3gi83l/EKHCswITm2c8NcdgXAnLw==}
-    engines: {node: '>=16.0.0'}
+  '@aws-sdk/middleware-user-agent@3.723.0':
+    resolution: {integrity: sha512-AY5H2vD3IRElplBO4DCyRMNnOG/4/cb0tsHyLe1HJy0hdUF6eY5z/VVjKJoKbbDk7ui9euyOBWslXxDyLmyPWg==}
+    engines: {node: '>=18.0.0'}
 
-  '@aws-sdk/region-config-resolver@3.667.0':
-    resolution: {integrity: sha512-iNr+JhhA902JMKHG9IwT9YdaEx6KGl6vjAL5BRNeOjfj4cZYMog6Lz/IlfOAltMtT0w88DAHDEFrBd2uO0l2eg==}
-    engines: {node: '>=16.0.0'}
+  '@aws-sdk/region-config-resolver@3.723.0':
+    resolution: {integrity: sha512-tGF/Cvch3uQjZIj34LY2mg8M2Dr4kYG8VU8Yd0dFnB1ybOEOveIK/9ypUo9ycZpB9oO6q01KRe5ijBaxNueUQg==}
+    engines: {node: '>=18.0.0'}
 
-  '@aws-sdk/token-providers@3.667.0':
-    resolution: {integrity: sha512-ZecJlG8p6D4UTYlBHwOWX6nknVtw/OBJ3yPXTSajBjhUlj9lE2xvejI8gl4rqkyLXk7z3bki+KR4tATbMaM9yg==}
-    engines: {node: '>=16.0.0'}
+  '@aws-sdk/token-providers@3.723.0':
+    resolution: {integrity: sha512-hniWi1x4JHVwKElANh9afKIMUhAutHVBRD8zo6usr0PAoj+Waf220+1ULS74GXtLXAPCiNXl5Og+PHA7xT8ElQ==}
+    engines: {node: '>=18.0.0'}
     peerDependencies:
-      '@aws-sdk/client-sso-oidc': ^3.667.0
+      '@aws-sdk/client-sso-oidc': ^3.723.0
 
-  '@aws-sdk/types@3.667.0':
-    resolution: {integrity: sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==}
-    engines: {node: '>=16.0.0'}
+  '@aws-sdk/types@3.723.0':
+    resolution: {integrity: sha512-LmK3kwiMZG1y5g3LGihT9mNkeNOmwEyPk6HGcJqh0wOSV4QpWoKu2epyKE4MLQNUUlz2kOVbVbOrwmI6ZcteuA==}
+    engines: {node: '>=18.0.0'}
 
-  '@aws-sdk/util-endpoints@3.667.0':
-    resolution: {integrity: sha512-X22SYDAuQJWnkF1/q17pkX3nGw5XMD9YEUbmt87vUnRq7iyJ3JOpl6UKOBeUBaL838wA5yzdbinmCITJ/VZ1QA==}
-    engines: {node: '>=16.0.0'}
+  '@aws-sdk/util-endpoints@3.723.0':
+    resolution: {integrity: sha512-vR1ZfAUvrTtdA1Q78QxgR8TFgi2gzk+N4EmNjbyR5hHmeOXuaKRdhbNQAzLPYVe1aNUpoiy9cl8mWkg9SrNHBw==}
+    engines: {node: '>=18.0.0'}
 
-  '@aws-sdk/util-locate-window@3.568.0':
-    resolution: {integrity: sha512-3nh4TINkXYr+H41QaPelCceEB2FXP3fxp93YZXB/kqJvX0U9j0N0Uk45gvsjmEPzG8XxkPEeLIfT2I1M7A6Lig==}
-    engines: {node: '>=16.0.0'}
+  '@aws-sdk/util-locate-window@3.723.0':
+    resolution: {integrity: sha512-Yf2CS10BqK688DRsrKI/EO6B8ff5J86NXe4C+VCysK7UOgN0l1zOTeTukZ3H8Q9tYYX3oaF1961o8vRkFm7Nmw==}
+    engines: {node: '>=18.0.0'}
 
-  '@aws-sdk/util-user-agent-browser@3.667.0':
-    resolution: {integrity: sha512-y1pKlNzNpxzddM0QSnfIfIbi3Z9LTag1VDjYyZRbEGGSVip2J00qKsET+979nRezWMyJgw5GPBQR3Y+rN+jh0Q==}
+  '@aws-sdk/util-user-agent-browser@3.723.0':
+    resolution: {integrity: sha512-Wh9I6j2jLhNFq6fmXydIpqD1WyQLyTfSxjW9B+PXSnPyk3jtQW8AKQur7p97rO8LAUzVI0bv8kb3ZzDEVbquIg==}
 
-  '@aws-sdk/util-user-agent-node@3.668.0':
-    resolution: {integrity: sha512-A27U+G/R5ekZhf6L2yVOX6/YQqmAxOiV61M+a9Jy1eG6YDOXueYUYXaHUkLWy15sNB0TPJNdsApn1rJdvHI0AQ==}
-    engines: {node: '>=16.0.0'}
+  '@aws-sdk/util-user-agent-node@3.723.0':
+    resolution: {integrity: sha512-uCtW5sGq8jCwA9w57TvVRIwNnPbSDD1lJaTIgotf7Jit2bTrYR64thgMy/drL5yU5aHOdFIQljqn/5aDXLtTJw==}
+    engines: {node: '>=18.0.0'}
     peerDependencies:
       aws-crt: '>=1.0.0'
     peerDependenciesMeta:
@@ -827,8 +827,8 @@ packages:
     resolution: {integrity: sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==}
     engines: {node: '>= 16'}
 
-  '@noble/hashes@1.6.1':
-    resolution: {integrity: sha512-pq5D8h10hHBjyqX+cfBm0i8JUXJ0UhczFc4r74zbuT9XgewFo2E3J1cOaGtdZynILNmQ685YWGzGE1Zv6io50w==}
+  '@noble/hashes@1.7.0':
+    resolution: {integrity: sha512-HXydb0DgzTpDPwbVeDGCG1gIu7X6+AuU6Zl6av/E/KG8LMsvPntvq+w17CHRpKBmN6Ybdrt1eP3k4cj8DJa78w==}
     engines: {node: ^14.21.3 || >=16}
 
   '@nodelib/fs.scandir@2.1.5':
@@ -1441,169 +1441,173 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@smithy/abort-controller@3.1.5':
-    resolution: {integrity: sha512-DhNPnqTqPoG8aZ5dWkFOgsuY+i0GQ3CI6hMmvCoduNsnU9gUZWZBwGfDQsTTB7NvFPkom1df7jMIJWU90kuXXg==}
-    engines: {node: '>=16.0.0'}
+  '@smithy/abort-controller@4.0.0':
+    resolution: {integrity: sha512-xFNL1ZfluscKiVI0qlPEnu7pL1UgNNIzQdjTPkaO7JCJtIkbArPYNtqbxohuNaQdksJ01Tn1wLbDA5oIp62P8w==}
+    engines: {node: '>=18.0.0'}
 
-  '@smithy/config-resolver@3.0.9':
-    resolution: {integrity: sha512-5d9oBf40qC7n2xUoHmntKLdqsyTMMo/r49+eqSIjJ73eDfEtljAxEhzIQ3bkgXJtR3xiv7YzMT/3FF3ORkjWdg==}
-    engines: {node: '>=16.0.0'}
+  '@smithy/config-resolver@4.0.0':
+    resolution: {integrity: sha512-29pIDlUY/a9+ChJPAarPiD9cU8fBtBh0wFnmnhj7j5AhgMzc+uyXdfzmziH6xx2jzw54waSP3HfnFkTANZuPYA==}
+    engines: {node: '>=18.0.0'}
 
-  '@smithy/core@2.4.8':
-    resolution: {integrity: sha512-x4qWk7p/a4dcf7Vxb2MODIf4OIcqNbK182WxRvZ/3oKPrf/6Fdic5sSElhO1UtXpWKBazWfqg0ZEK9xN1DsuHA==}
-    engines: {node: '>=16.0.0'}
+  '@smithy/core@3.0.0':
+    resolution: {integrity: sha512-pKaas7RWvPljJ8uByCeBa10rtbVJCy4N/Fr7OSPxFezcyG0SQuXWnESZqzXj7m2+A+kPzG6fKyP4wrKidl2Ikg==}
+    engines: {node: '>=18.0.0'}
 
-  '@smithy/credential-provider-imds@3.2.4':
-    resolution: {integrity: sha512-S9bb0EIokfYEuar4kEbLta+ivlKCWOCFsLZuilkNy9i0uEUEHSi47IFLPaxqqCl+0ftKmcOTHayY5nQhAuq7+w==}
-    engines: {node: '>=16.0.0'}
+  '@smithy/credential-provider-imds@4.0.0':
+    resolution: {integrity: sha512-+hTShyZHiq2AVFOxJja3k6O17DKU6TaZbwr2y1OH5HQtUw2a+7O3mMR+10LVmc39ef72SAj+uFX0IW9rJGaLQQ==}
+    engines: {node: '>=18.0.0'}
 
-  '@smithy/fetch-http-handler@3.2.9':
-    resolution: {integrity: sha512-hYNVQOqhFQ6vOpenifFME546f0GfJn2OiQ3M0FDmuUu8V/Uiwy2wej7ZXxFBNqdx0R5DZAqWM1l6VRhGz8oE6A==}
+  '@smithy/fetch-http-handler@5.0.0':
+    resolution: {integrity: sha512-jUEq+4056uqsDLRqQb1fm48rrSMBYcBxVvODfiP37ORcV5n9xWJQsINWcIffyYxWTM5K0Y/GOfhSQGDtWpAPpQ==}
+    engines: {node: '>=18.0.0'}
 
-  '@smithy/hash-node@3.0.7':
-    resolution: {integrity: sha512-SAGHN+QkrwcHFjfWzs/czX94ZEjPJ0CrWJS3M43WswDXVEuP4AVy9gJ3+AF6JQHZD13bojmuf/Ap/ItDeZ+Qfw==}
-    engines: {node: '>=16.0.0'}
+  '@smithy/hash-node@4.0.0':
+    resolution: {integrity: sha512-25OxGYGnG3JPEOTk4iFE03bfmoC6GXUQ4L13z4cNdsS3mkncH22AGSDRfKwwEqutNUxXQZWVy9f72Fm59C9qlg==}
+    engines: {node: '>=18.0.0'}
 
-  '@smithy/invalid-dependency@3.0.7':
-    resolution: {integrity: sha512-Bq00GsAhHeYSuZX8Kpu4sbI9agH2BNYnqUmmbTGWOhki9NVsWn2jFr896vvoTMH8KAjNX/ErC/8t5QHuEXG+IA==}
+  '@smithy/invalid-dependency@4.0.0':
+    resolution: {integrity: sha512-0GTyet02HX/sPctEhOExY+3HI7hwkVwOoJg0XnItTJ+Xw7JMuL9FOxALTmKVIV6+wg0kF6veLeg72hVSbD9UCw==}
+    engines: {node: '>=18.0.0'}
 
   '@smithy/is-array-buffer@2.2.0':
     resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
     engines: {node: '>=14.0.0'}
 
-  '@smithy/is-array-buffer@3.0.0':
-    resolution: {integrity: sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==}
-    engines: {node: '>=16.0.0'}
+  '@smithy/is-array-buffer@4.0.0':
+    resolution: {integrity: sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==}
+    engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-content-length@3.0.9':
-    resolution: {integrity: sha512-t97PidoGElF9hTtLCrof32wfWMqC5g2SEJNxaVH3NjlatuNGsdxXRYO/t+RPnxA15RpYiS0f+zG7FuE2DeGgjA==}
-    engines: {node: '>=16.0.0'}
+  '@smithy/middleware-content-length@4.0.0':
+    resolution: {integrity: sha512-nM1RJqLwkSCidumGK8WwNEZ0a0D/4LkwqdPna+QmHrdPoAK6WGLyZFosdMpsAW1OIbDLWGa+r37Mo4Vth4S4kQ==}
+    engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-endpoint@3.1.4':
-    resolution: {integrity: sha512-/ChcVHekAyzUbyPRI8CzPPLj6y8QRAfJngWcLMgsWxKVzw/RzBV69mSOzJYDD3pRwushA1+5tHtPF8fjmzBnrQ==}
-    engines: {node: '>=16.0.0'}
+  '@smithy/middleware-endpoint@4.0.0':
+    resolution: {integrity: sha512-/f6z5SqUurmqemhBZNhM0c+C7QW0AY/zJpic//sbdu26q98HSPAI/xvzStjYq+UhtWeAe/jaX6gamdL/2r3W1g==}
+    engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-retry@3.0.23':
-    resolution: {integrity: sha512-x9PbGXxkcXIpm6L26qRSCC+eaYcHwybRmqU8LO/WM2RRlW0g8lz6FIiKbKgGvHuoK3dLZRiQVSQJveiCzwnA5A==}
-    engines: {node: '>=16.0.0'}
+  '@smithy/middleware-retry@4.0.0':
+    resolution: {integrity: sha512-K6tsFp3Ik44H3694a+LWoXLV8mqy8zn6/vTw2feU72MaIzi51EHMVNNxxpL6e2GI6oxw8FFRGWgGn8+wQRrHZQ==}
+    engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-serde@3.0.7':
-    resolution: {integrity: sha512-VytaagsQqtH2OugzVTq4qvjkLNbWehHfGcGr0JLJmlDRrNCeZoWkWsSOw1nhS/4hyUUWF/TLGGml4X/OnEep5g==}
-    engines: {node: '>=16.0.0'}
+  '@smithy/middleware-serde@4.0.0':
+    resolution: {integrity: sha512-aW4Zo8Cm988RCvhysErzqrQ4YPKgZFhajvgPoZnsWIDaZfT419J17Ahr13Lul3kqGad2dCz7YOrXd7r+UAEj/w==}
+    engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-stack@3.0.7':
-    resolution: {integrity: sha512-EyTbMCdqS1DoeQsO4gI7z2Gzq1MoRFAeS8GkFYIwbedB7Lp5zlLHJdg+56tllIIG5Hnf9ZWX48YKSHlsKvugGA==}
-    engines: {node: '>=16.0.0'}
+  '@smithy/middleware-stack@4.0.0':
+    resolution: {integrity: sha512-4NFaX88RmgVrCyJv/3RsSdqMwxzI/EQa8nvhUDVxmLUMRS2JUdHnliD6IwKuqIwIzz+E1aZK3EhSHUM4HXp3ww==}
+    engines: {node: '>=18.0.0'}
 
-  '@smithy/node-config-provider@3.1.8':
-    resolution: {integrity: sha512-E0rU0DglpeJn5ge64mk8wTGEXcQwmpUTY5Zr7IzTpDLmHKiIamINERNZYrPQjg58Ck236sEKSwRSHA4CwshU6Q==}
-    engines: {node: '>=16.0.0'}
+  '@smithy/node-config-provider@4.0.0':
+    resolution: {integrity: sha512-Crp9rg1ewjqgM2i7pWSpNhfbBa0usyKGDVQLEXTOpu6trFqq3BFLLCgbCE1S18h6mxqKnOqUONq3nWOxUk75XA==}
+    engines: {node: '>=18.0.0'}
 
-  '@smithy/node-http-handler@3.2.4':
-    resolution: {integrity: sha512-49reY3+JgLMFNm7uTAKBWiKCA6XSvkNp9FqhVmusm2jpVnHORYFeFZ704LShtqWfjZW/nhX+7Iexyb6zQfXYIQ==}
-    engines: {node: '>=16.0.0'}
+  '@smithy/node-http-handler@4.0.0':
+    resolution: {integrity: sha512-WvumtEaFyxaI95zmj6eYlF/vCFCKNyru3P/UUHCUS9BjvajUtNckH2cY3bBfi+qqMPX5gha4g26lcOlE/wPz/Q==}
+    engines: {node: '>=18.0.0'}
 
-  '@smithy/property-provider@3.1.7':
-    resolution: {integrity: sha512-QfzLi1GPMisY7bAM5hOUqBdGYnY5S2JAlr201pghksrQv139f8iiiMalXtjczIP5f6owxFn3MINLNUNvUkgtPw==}
-    engines: {node: '>=16.0.0'}
+  '@smithy/property-provider@4.0.0':
+    resolution: {integrity: sha512-AJSvY1k3SdM0stGrIjL8/FIjXO7X9I7KkznXDmr76RGz+yvaDHLsLm2hSHyzAlmwEQnHaafSU2dwaV0JcnR/4w==}
+    engines: {node: '>=18.0.0'}
 
-  '@smithy/protocol-http@4.1.4':
-    resolution: {integrity: sha512-MlWK8eqj0JlpZBnWmjQLqmFp71Ug00P+m72/1xQB3YByXD4zZ+y9N4hYrR0EDmrUCZIkyATWHOXFgtavwGDTzQ==}
-    engines: {node: '>=16.0.0'}
+  '@smithy/protocol-http@5.0.0':
+    resolution: {integrity: sha512-laAcIHWq9GQ5VdAS71DUrCj5HUHZ/89Ee+HRTLhFR5/E3toBlnZfPG+kqBajwfEB5aSdRuKslfzl5Dzrn3pr8A==}
+    engines: {node: '>=18.0.0'}
 
-  '@smithy/querystring-builder@3.0.7':
-    resolution: {integrity: sha512-65RXGZZ20rzqqxTsChdqSpbhA6tdt5IFNgG6o7e1lnPVLCe6TNWQq4rTl4N87hTDD8mV4IxJJnvyE7brbnRkQw==}
-    engines: {node: '>=16.0.0'}
+  '@smithy/querystring-builder@4.0.0':
+    resolution: {integrity: sha512-kMqPDRf+/hwm+Dmk8AQCaYTJxNWWpNdJJteeMm0jwDbmRDqSqHQ7oLEVzvOnbWJu1poVtOhv6v7jsbyx9JASsw==}
+    engines: {node: '>=18.0.0'}
 
-  '@smithy/querystring-parser@3.0.7':
-    resolution: {integrity: sha512-Fouw4KJVWqqUVIu1gZW8BH2HakwLz6dvdrAhXeXfeymOBrZw+hcqaWs+cS1AZPVp4nlbeIujYrKA921ZW2WMPA==}
-    engines: {node: '>=16.0.0'}
+  '@smithy/querystring-parser@4.0.0':
+    resolution: {integrity: sha512-SbogL1PNEmm28ya0eK2S0EZEbYwe0qpaqSGrODm+uYS6dQ7pekPLVNXjBRuuLIAT26ZF2wTsp6X7AVRBNZd8qw==}
+    engines: {node: '>=18.0.0'}
 
-  '@smithy/service-error-classification@3.0.7':
-    resolution: {integrity: sha512-91PRkTfiBf9hxkIchhRKJfl1rsplRDyBnmyFca3y0Z3x/q0JJN480S83LBd8R6sBCkm2bBbqw2FHp0Mbh+ecSA==}
-    engines: {node: '>=16.0.0'}
+  '@smithy/service-error-classification@4.0.0':
+    resolution: {integrity: sha512-hIZreT6aXSG0PK/psT1S+kfeGTnYnRRlf7rU3yDmH/crSVjTbS/5h5w2J7eO2ODrQb3xfhJcYxQBREdwsZk6TA==}
+    engines: {node: '>=18.0.0'}
 
-  '@smithy/shared-ini-file-loader@3.1.8':
-    resolution: {integrity: sha512-0NHdQiSkeGl0ICQKcJQ2lCOKH23Nb0EaAa7RDRId6ZqwXkw4LJyIyZ0t3iusD4bnKYDPLGy2/5e2rfUhrt0Acw==}
-    engines: {node: '>=16.0.0'}
+  '@smithy/shared-ini-file-loader@4.0.0':
+    resolution: {integrity: sha512-Ktupe8msp2GPaKKVfiz3NNUNnslJiGGRoVh3BDpm/RChkQ5INQpqmTc2taE0XChNYumNynLfb3keekIPaiaZeg==}
+    engines: {node: '>=18.0.0'}
 
-  '@smithy/signature-v4@4.2.0':
-    resolution: {integrity: sha512-LafbclHNKnsorMgUkKm7Tk7oJ7xizsZ1VwqhGKqoCIrXh4fqDDp73fK99HOEEgcsQbtemmeY/BPv0vTVYYUNEQ==}
-    engines: {node: '>=16.0.0'}
+  '@smithy/signature-v4@5.0.0':
+    resolution: {integrity: sha512-zqcOR1sZTuoA6K3PBNwzu4YgT1pmIwz47tYpgaJjBTfGUIMtcjUaXKtuSKEScdv+0wx45/PbXz0//hk80fky3w==}
+    engines: {node: '>=18.0.0'}
 
-  '@smithy/smithy-client@3.4.0':
-    resolution: {integrity: sha512-nOfJ1nVQsxiP6srKt43r2My0Gp5PLWCW2ASqUioxIiGmu6d32v4Nekidiv5qOmmtzIrmaD+ADX5SKHUuhReeBQ==}
-    engines: {node: '>=16.0.0'}
+  '@smithy/smithy-client@4.0.0':
+    resolution: {integrity: sha512-AgcZ6B+JuqArYioAbaYrCpTCjYsD3/1hPSXntbN2ipsfc4hE+72RFZevUPYgsKxpy3G+QxuLfqm11i3+oX4oSA==}
+    engines: {node: '>=18.0.0'}
 
-  '@smithy/types@3.5.0':
-    resolution: {integrity: sha512-QN0twHNfe8mNJdH9unwsCK13GURU7oEAZqkBI+rsvpv1jrmserO+WnLE7jidR9W/1dxwZ0u/CB01mV2Gms/K2Q==}
-    engines: {node: '>=16.0.0'}
+  '@smithy/types@4.0.0':
+    resolution: {integrity: sha512-aNwIGSOgDOhtTRY/rrn2aeuQeKw/IFrQ998yK5l6Ah853WeWIEmFPs/EO4OpfADEdcK+igWnZytm/oUgkLgUYg==}
+    engines: {node: '>=18.0.0'}
 
-  '@smithy/url-parser@3.0.7':
-    resolution: {integrity: sha512-70UbSSR8J97c1rHZOWhl+VKiZDqHWxs/iW8ZHrHp5fCCPLSBE7GcUlUvKSle3Ca+J9LLbYCj/A79BxztBvAfpA==}
+  '@smithy/url-parser@4.0.0':
+    resolution: {integrity: sha512-2iPpuLoH0hCKpLtqVgilHtpPKsmHihbkwBm3h3RPuEctdmuiOlFRZ2ZI8IHSwl0o4ff5IdyyJ0yu/2tS9KpUug==}
+    engines: {node: '>=18.0.0'}
 
-  '@smithy/util-base64@3.0.0':
-    resolution: {integrity: sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==}
-    engines: {node: '>=16.0.0'}
+  '@smithy/util-base64@4.0.0':
+    resolution: {integrity: sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg==}
+    engines: {node: '>=18.0.0'}
 
-  '@smithy/util-body-length-browser@3.0.0':
-    resolution: {integrity: sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==}
+  '@smithy/util-body-length-browser@4.0.0':
+    resolution: {integrity: sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==}
+    engines: {node: '>=18.0.0'}
 
-  '@smithy/util-body-length-node@3.0.0':
-    resolution: {integrity: sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==}
-    engines: {node: '>=16.0.0'}
+  '@smithy/util-body-length-node@4.0.0':
+    resolution: {integrity: sha512-q0iDP3VsZzqJyje8xJWEJCNIu3lktUGVoSy1KB0UWym2CL1siV3artm+u1DFYTLejpsrdGyCSWBdGNjJzfDPjg==}
+    engines: {node: '>=18.0.0'}
 
   '@smithy/util-buffer-from@2.2.0':
     resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
     engines: {node: '>=14.0.0'}
 
-  '@smithy/util-buffer-from@3.0.0':
-    resolution: {integrity: sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==}
-    engines: {node: '>=16.0.0'}
+  '@smithy/util-buffer-from@4.0.0':
+    resolution: {integrity: sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==}
+    engines: {node: '>=18.0.0'}
 
-  '@smithy/util-config-provider@3.0.0':
-    resolution: {integrity: sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==}
-    engines: {node: '>=16.0.0'}
+  '@smithy/util-config-provider@4.0.0':
+    resolution: {integrity: sha512-L1RBVzLyfE8OXH+1hsJ8p+acNUSirQnWQ6/EgpchV88G6zGBTDPdXiiExei6Z1wR2RxYvxY/XLw6AMNCCt8H3w==}
+    engines: {node: '>=18.0.0'}
 
-  '@smithy/util-defaults-mode-browser@3.0.23':
-    resolution: {integrity: sha512-Y07qslyRtXDP/C5aWKqxTPBl4YxplEELG3xRrz2dnAQ6Lq/FgNrcKWmV561nNaZmFH+EzeGOX3ZRMbU8p1T6Nw==}
-    engines: {node: '>= 10.0.0'}
+  '@smithy/util-defaults-mode-browser@4.0.0':
+    resolution: {integrity: sha512-7wqsXkzaJkpSqV+Ca95pN9yQutXvhaKeCxGGmjWnRGXY1fW/yR7wr1ouNnUYCJuTS8MvmB61xp5Qdj8YMgIA2Q==}
+    engines: {node: '>=18.0.0'}
 
-  '@smithy/util-defaults-mode-node@3.0.23':
-    resolution: {integrity: sha512-9Y4WH7f0vnDGuHUa4lGX9e2p+sMwODibsceSV6rfkZOvMC+BY3StB2LdO1NHafpsyHJLpwAgChxQ38tFyd6vkg==}
-    engines: {node: '>= 10.0.0'}
+  '@smithy/util-defaults-mode-node@4.0.0':
+    resolution: {integrity: sha512-P8VK885kiRT6TEtvcQvz+L/+xIhrDhCmM664ToUtrshFSBhwGYaJWlQNAH9fXlMhwnNvR+tmh1KngKJIgQP6bw==}
+    engines: {node: '>=18.0.0'}
 
-  '@smithy/util-endpoints@2.1.3':
-    resolution: {integrity: sha512-34eACeKov6jZdHqS5hxBMJ4KyWKztTMulhuQ2UdOoP6vVxMLrOKUqIXAwJe/wiWMhXhydLW664B02CNpQBQ4Aw==}
-    engines: {node: '>=16.0.0'}
+  '@smithy/util-endpoints@3.0.0':
+    resolution: {integrity: sha512-kyOKbkg77lsIVN2jC08uEWm3s16eK1YdVDyi/nKeBDbUnjR30dmTEga79E5tiu5OEgTAdngNswA9V+L6xa65sA==}
+    engines: {node: '>=18.0.0'}
 
-  '@smithy/util-hex-encoding@3.0.0':
-    resolution: {integrity: sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==}
-    engines: {node: '>=16.0.0'}
+  '@smithy/util-hex-encoding@4.0.0':
+    resolution: {integrity: sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==}
+    engines: {node: '>=18.0.0'}
 
-  '@smithy/util-middleware@3.0.7':
-    resolution: {integrity: sha512-OVA6fv/3o7TMJTpTgOi1H5OTwnuUa8hzRzhSFDtZyNxi6OZ70L/FHattSmhE212I7b6WSOJAAmbYnvcjTHOJCA==}
-    engines: {node: '>=16.0.0'}
+  '@smithy/util-middleware@4.0.0':
+    resolution: {integrity: sha512-ncuvK6ekpDqtASHg7jx3d3nrkD2BsTzUmeVgvtepuHGxtySY8qUlb4SiNRdxHYcv3pL2SwdXs70RwKBU0edW5w==}
+    engines: {node: '>=18.0.0'}
 
-  '@smithy/util-retry@3.0.7':
-    resolution: {integrity: sha512-nh1ZO1vTeo2YX1plFPSe/OXaHkLAHza5jpokNiiKX2M5YpNUv6RxGJZhpfmiR4jSvVHCjIDmILjrxKmP+/Ghug==}
-    engines: {node: '>=16.0.0'}
+  '@smithy/util-retry@4.0.0':
+    resolution: {integrity: sha512-64WFoC19NVuHh3HQO2QbGw+n6GzQ6VH/drxwXLOU3GDLKxUUzIR9XNm9aTVqh8/7R+y+DgITiv5LpX5XdOy73A==}
+    engines: {node: '>=18.0.0'}
 
-  '@smithy/util-stream@3.1.9':
-    resolution: {integrity: sha512-7YAR0Ub3MwTMjDfjnup4qa6W8gygZMxikBhFMPESi6ASsl/rZJhwLpF/0k9TuezScCojsM0FryGdz4LZtjKPPQ==}
-    engines: {node: '>=16.0.0'}
+  '@smithy/util-stream@4.0.0':
+    resolution: {integrity: sha512-ctcLq8Ogi2FQuGy2RxJXGGrozhFEb4p9FawB5SpTNAkNQWbNHcwrGcVSVI3FtdQtkNAINLiEdMnrx+UN/mafvw==}
+    engines: {node: '>=18.0.0'}
 
-  '@smithy/util-uri-escape@3.0.0':
-    resolution: {integrity: sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==}
-    engines: {node: '>=16.0.0'}
+  '@smithy/util-uri-escape@4.0.0':
+    resolution: {integrity: sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==}
+    engines: {node: '>=18.0.0'}
 
   '@smithy/util-utf8@2.3.0':
     resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
     engines: {node: '>=14.0.0'}
 
-  '@smithy/util-utf8@3.0.0':
-    resolution: {integrity: sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==}
-    engines: {node: '>=16.0.0'}
+  '@smithy/util-utf8@4.0.0':
+    resolution: {integrity: sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==}
+    engines: {node: '>=18.0.0'}
 
   '@stytch/core@2.28.0':
     resolution: {integrity: sha512-KZEVFFt9DW6sh7rnyyfLVb+4Iro+gqEghYzcfVC/kOonLVJqdGlG7Sz0g4VMZyXe/QZpZ4kMSwj80lmYGR1QZg==}
@@ -3283,63 +3287,63 @@ packages:
 
 snapshots:
 
-  0xsequence@2.1.3(ethers@6.13.3):
+  0xsequence@2.2.4(ethers@6.13.3):
     dependencies:
-      '@0xsequence/abi': 2.1.3
-      '@0xsequence/account': 2.1.3(ethers@6.13.3)
-      '@0xsequence/api': 2.1.3
-      '@0xsequence/auth': 2.1.3(ethers@6.13.3)
-      '@0xsequence/core': 2.1.3(ethers@6.13.3)
-      '@0xsequence/guard': 2.1.3(ethers@6.13.3)
-      '@0xsequence/indexer': 2.1.3
-      '@0xsequence/metadata': 2.1.3
-      '@0xsequence/migration': 2.1.3(ethers@6.13.3)
-      '@0xsequence/network': 2.1.3(ethers@6.13.3)
-      '@0xsequence/provider': 2.1.3(ethers@6.13.3)
-      '@0xsequence/relayer': 2.1.3(ethers@6.13.3)
-      '@0xsequence/sessions': 2.1.3(ethers@6.13.3)
-      '@0xsequence/signhub': 2.1.3(ethers@6.13.3)
-      '@0xsequence/utils': 2.1.3(ethers@6.13.3)
-      '@0xsequence/wallet': 2.1.3(ethers@6.13.3)
+      '@0xsequence/abi': 2.2.4
+      '@0xsequence/account': 2.2.4(ethers@6.13.3)
+      '@0xsequence/api': 2.2.4
+      '@0xsequence/auth': 2.2.4(ethers@6.13.3)
+      '@0xsequence/core': 2.2.4(ethers@6.13.3)
+      '@0xsequence/guard': 2.2.4(ethers@6.13.3)
+      '@0xsequence/indexer': 2.2.4
+      '@0xsequence/metadata': 2.2.4
+      '@0xsequence/migration': 2.2.4(ethers@6.13.3)
+      '@0xsequence/network': 2.2.4(ethers@6.13.3)
+      '@0xsequence/provider': 2.2.4(ethers@6.13.3)
+      '@0xsequence/relayer': 2.2.4(ethers@6.13.3)
+      '@0xsequence/sessions': 2.2.4(ethers@6.13.3)
+      '@0xsequence/signhub': 2.2.4(ethers@6.13.3)
+      '@0xsequence/utils': 2.2.4(ethers@6.13.3)
+      '@0xsequence/wallet': 2.2.4(ethers@6.13.3)
       ethers: 6.13.3
 
-  '@0xsequence/abi@2.1.3': {}
+  '@0xsequence/abi@2.2.4': {}
 
-  '@0xsequence/account@2.1.3(ethers@6.13.3)':
+  '@0xsequence/account@2.2.4(ethers@6.13.3)':
     dependencies:
-      '@0xsequence/abi': 2.1.3
-      '@0xsequence/core': 2.1.3(ethers@6.13.3)
-      '@0xsequence/migration': 2.1.3(ethers@6.13.3)
-      '@0xsequence/network': 2.1.3(ethers@6.13.3)
-      '@0xsequence/relayer': 2.1.3(ethers@6.13.3)
-      '@0xsequence/sessions': 2.1.3(ethers@6.13.3)
-      '@0xsequence/utils': 2.1.3(ethers@6.13.3)
-      '@0xsequence/wallet': 2.1.3(ethers@6.13.3)
+      '@0xsequence/abi': 2.2.4
+      '@0xsequence/core': 2.2.4(ethers@6.13.3)
+      '@0xsequence/migration': 2.2.4(ethers@6.13.3)
+      '@0xsequence/network': 2.2.4(ethers@6.13.3)
+      '@0xsequence/relayer': 2.2.4(ethers@6.13.3)
+      '@0xsequence/sessions': 2.2.4(ethers@6.13.3)
+      '@0xsequence/utils': 2.2.4(ethers@6.13.3)
+      '@0xsequence/wallet': 2.2.4(ethers@6.13.3)
       ethers: 6.13.3
 
-  '@0xsequence/api@2.1.3': {}
+  '@0xsequence/api@2.2.4': {}
 
-  '@0xsequence/auth@2.1.3(ethers@6.13.3)':
+  '@0xsequence/auth@2.2.4(ethers@6.13.3)':
     dependencies:
-      '@0xsequence/abi': 2.1.3
-      '@0xsequence/account': 2.1.3(ethers@6.13.3)
-      '@0xsequence/api': 2.1.3
-      '@0xsequence/core': 2.1.3(ethers@6.13.3)
+      '@0xsequence/abi': 2.2.4
+      '@0xsequence/account': 2.2.4(ethers@6.13.3)
+      '@0xsequence/api': 2.2.4
+      '@0xsequence/core': 2.2.4(ethers@6.13.3)
       '@0xsequence/ethauth': 1.0.0(ethers@6.13.3)
-      '@0xsequence/indexer': 2.1.3
-      '@0xsequence/metadata': 2.1.3
-      '@0xsequence/migration': 2.1.3(ethers@6.13.3)
-      '@0xsequence/network': 2.1.3(ethers@6.13.3)
-      '@0xsequence/sessions': 2.1.3(ethers@6.13.3)
-      '@0xsequence/signhub': 2.1.3(ethers@6.13.3)
-      '@0xsequence/utils': 2.1.3(ethers@6.13.3)
-      '@0xsequence/wallet': 2.1.3(ethers@6.13.3)
+      '@0xsequence/indexer': 2.2.4
+      '@0xsequence/metadata': 2.2.4
+      '@0xsequence/migration': 2.2.4(ethers@6.13.3)
+      '@0xsequence/network': 2.2.4(ethers@6.13.3)
+      '@0xsequence/sessions': 2.2.4(ethers@6.13.3)
+      '@0xsequence/signhub': 2.2.4(ethers@6.13.3)
+      '@0xsequence/utils': 2.2.4(ethers@6.13.3)
+      '@0xsequence/wallet': 2.2.4(ethers@6.13.3)
       ethers: 6.13.3
 
-  '@0xsequence/core@2.1.3(ethers@6.13.3)':
+  '@0xsequence/core@2.2.4(ethers@6.13.3)':
     dependencies:
-      '@0xsequence/abi': 2.1.3
-      '@0xsequence/utils': 2.1.3(ethers@6.13.3)
+      '@0xsequence/abi': 2.2.4
+      '@0xsequence/utils': 2.2.4(ethers@6.13.3)
       ethers: 6.13.3
 
   '@0xsequence/design-system@1.7.8(@types/react-dom@18.3.0)(@types/react@18.3.11)(framer-motion@11.11.7(@emotion/is-prop-valid@1.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
@@ -3370,87 +3374,87 @@ snapshots:
       ethers: 6.13.3
       js-base64: 3.7.7
 
-  '@0xsequence/guard@2.1.3(ethers@6.13.3)':
+  '@0xsequence/guard@2.2.4(ethers@6.13.3)':
     dependencies:
-      '@0xsequence/account': 2.1.3(ethers@6.13.3)
-      '@0xsequence/core': 2.1.3(ethers@6.13.3)
-      '@0xsequence/signhub': 2.1.3(ethers@6.13.3)
-      '@0xsequence/utils': 2.1.3(ethers@6.13.3)
+      '@0xsequence/account': 2.2.4(ethers@6.13.3)
+      '@0xsequence/core': 2.2.4(ethers@6.13.3)
+      '@0xsequence/signhub': 2.2.4(ethers@6.13.3)
+      '@0xsequence/utils': 2.2.4(ethers@6.13.3)
       ethers: 6.13.3
 
-  '@0xsequence/indexer@2.1.3': {}
+  '@0xsequence/indexer@2.2.4': {}
 
-  '@0xsequence/metadata@2.1.3': {}
+  '@0xsequence/metadata@2.2.4': {}
 
-  '@0xsequence/migration@2.1.3(ethers@6.13.3)':
+  '@0xsequence/migration@2.2.4(ethers@6.13.3)':
     dependencies:
-      '@0xsequence/abi': 2.1.3
-      '@0xsequence/core': 2.1.3(ethers@6.13.3)
-      '@0xsequence/wallet': 2.1.3(ethers@6.13.3)
+      '@0xsequence/abi': 2.2.4
+      '@0xsequence/core': 2.2.4(ethers@6.13.3)
+      '@0xsequence/wallet': 2.2.4(ethers@6.13.3)
       ethers: 6.13.3
 
-  '@0xsequence/network@2.1.3(ethers@6.13.3)':
+  '@0xsequence/network@2.2.4(ethers@6.13.3)':
     dependencies:
-      '@0xsequence/core': 2.1.3(ethers@6.13.3)
-      '@0xsequence/indexer': 2.1.3
-      '@0xsequence/relayer': 2.1.3(ethers@6.13.3)
-      '@0xsequence/utils': 2.1.3(ethers@6.13.3)
+      '@0xsequence/core': 2.2.4(ethers@6.13.3)
+      '@0xsequence/indexer': 2.2.4
+      '@0xsequence/relayer': 2.2.4(ethers@6.13.3)
+      '@0xsequence/utils': 2.2.4(ethers@6.13.3)
       ethers: 6.13.3
 
-  '@0xsequence/provider@2.1.3(ethers@6.13.3)':
+  '@0xsequence/provider@2.2.4(ethers@6.13.3)':
     dependencies:
-      '@0xsequence/abi': 2.1.3
-      '@0xsequence/account': 2.1.3(ethers@6.13.3)
-      '@0xsequence/auth': 2.1.3(ethers@6.13.3)
-      '@0xsequence/core': 2.1.3(ethers@6.13.3)
-      '@0xsequence/migration': 2.1.3(ethers@6.13.3)
-      '@0xsequence/network': 2.1.3(ethers@6.13.3)
-      '@0xsequence/relayer': 2.1.3(ethers@6.13.3)
-      '@0xsequence/utils': 2.1.3(ethers@6.13.3)
-      '@0xsequence/wallet': 2.1.3(ethers@6.13.3)
+      '@0xsequence/abi': 2.2.4
+      '@0xsequence/account': 2.2.4(ethers@6.13.3)
+      '@0xsequence/auth': 2.2.4(ethers@6.13.3)
+      '@0xsequence/core': 2.2.4(ethers@6.13.3)
+      '@0xsequence/migration': 2.2.4(ethers@6.13.3)
+      '@0xsequence/network': 2.2.4(ethers@6.13.3)
+      '@0xsequence/relayer': 2.2.4(ethers@6.13.3)
+      '@0xsequence/utils': 2.2.4(ethers@6.13.3)
+      '@0xsequence/wallet': 2.2.4(ethers@6.13.3)
       '@databeat/tracker': 0.9.3
       ethers: 6.13.3
       eventemitter2: 6.4.9
       webextension-polyfill: 0.10.0
 
-  '@0xsequence/relayer@2.1.3(ethers@6.13.3)':
+  '@0xsequence/relayer@2.2.4(ethers@6.13.3)':
     dependencies:
-      '@0xsequence/abi': 2.1.3
-      '@0xsequence/core': 2.1.3(ethers@6.13.3)
-      '@0xsequence/utils': 2.1.3(ethers@6.13.3)
+      '@0xsequence/abi': 2.2.4
+      '@0xsequence/core': 2.2.4(ethers@6.13.3)
+      '@0xsequence/utils': 2.2.4(ethers@6.13.3)
       ethers: 6.13.3
 
-  '@0xsequence/replacer@2.1.3(ethers@6.13.3)':
+  '@0xsequence/replacer@2.2.4(ethers@6.13.3)':
     dependencies:
-      '@0xsequence/abi': 2.1.3
-      '@0xsequence/core': 2.1.3(ethers@6.13.3)
+      '@0xsequence/abi': 2.2.4
+      '@0xsequence/core': 2.2.4(ethers@6.13.3)
       ethers: 6.13.3
 
-  '@0xsequence/sessions@2.1.3(ethers@6.13.3)':
+  '@0xsequence/sessions@2.2.4(ethers@6.13.3)':
     dependencies:
-      '@0xsequence/core': 2.1.3(ethers@6.13.3)
-      '@0xsequence/migration': 2.1.3(ethers@6.13.3)
-      '@0xsequence/replacer': 2.1.3(ethers@6.13.3)
-      '@0xsequence/utils': 2.1.3(ethers@6.13.3)
+      '@0xsequence/core': 2.2.4(ethers@6.13.3)
+      '@0xsequence/migration': 2.2.4(ethers@6.13.3)
+      '@0xsequence/replacer': 2.2.4(ethers@6.13.3)
+      '@0xsequence/utils': 2.2.4(ethers@6.13.3)
       ethers: 6.13.3
       idb: 7.1.1
 
-  '@0xsequence/signhub@2.1.3(ethers@6.13.3)':
+  '@0xsequence/signhub@2.2.4(ethers@6.13.3)':
     dependencies:
-      '@0xsequence/core': 2.1.3(ethers@6.13.3)
+      '@0xsequence/core': 2.2.4(ethers@6.13.3)
       ethers: 6.13.3
 
-  '@0xsequence/utils@2.1.3(ethers@6.13.3)':
+  '@0xsequence/utils@2.2.4(ethers@6.13.3)':
     dependencies:
       ethers: 6.13.3
       js-base64: 3.7.7
 
-  '@0xsequence/waas@2.1.3(ethers@6.13.3)':
+  '@0xsequence/waas@2.2.4(ethers@6.13.3)':
     dependencies:
-      '@0xsequence/core': 2.1.3(ethers@6.13.3)
-      '@0xsequence/network': 2.1.3(ethers@6.13.3)
-      '@0xsequence/utils': 2.1.3(ethers@6.13.3)
-      '@aws-sdk/client-cognito-identity-provider': 3.668.0
+      '@0xsequence/core': 2.2.4(ethers@6.13.3)
+      '@0xsequence/network': 2.2.4(ethers@6.13.3)
+      '@0xsequence/utils': 2.2.4(ethers@6.13.3)
+      '@aws-sdk/client-cognito-identity-provider': 3.723.0
       ethers: 6.13.3
       idb: 7.1.1
       json-canonicalize: 1.0.6
@@ -3458,14 +3462,14 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@0xsequence/wallet@2.1.3(ethers@6.13.3)':
+  '@0xsequence/wallet@2.2.4(ethers@6.13.3)':
     dependencies:
-      '@0xsequence/abi': 2.1.3
-      '@0xsequence/core': 2.1.3(ethers@6.13.3)
-      '@0xsequence/network': 2.1.3(ethers@6.13.3)
-      '@0xsequence/relayer': 2.1.3(ethers@6.13.3)
-      '@0xsequence/signhub': 2.1.3(ethers@6.13.3)
-      '@0xsequence/utils': 2.1.3(ethers@6.13.3)
+      '@0xsequence/abi': 2.2.4
+      '@0xsequence/core': 2.2.4(ethers@6.13.3)
+      '@0xsequence/network': 2.2.4(ethers@6.13.3)
+      '@0xsequence/relayer': 2.2.4(ethers@6.13.3)
+      '@0xsequence/signhub': 2.2.4(ethers@6.13.3)
+      '@0xsequence/utils': 2.2.4(ethers@6.13.3)
       ethers: 6.13.3
 
   '@adraffy/ens-normalize@1.10.1': {}
@@ -3480,15 +3484,15 @@ snapshots:
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.667.0
-      '@aws-sdk/util-locate-window': 3.568.0
+      '@aws-sdk/types': 3.723.0
+      '@aws-sdk/util-locate-window': 3.723.0
       '@smithy/util-utf8': 2.3.0
       tslib: 2.7.0
 
   '@aws-crypto/sha256-js@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.667.0
+      '@aws-sdk/types': 3.723.0
       tslib: 2.7.0
 
   '@aws-crypto/supports-web-crypto@5.2.0':
@@ -3497,371 +3501,371 @@ snapshots:
 
   '@aws-crypto/util@5.2.0':
     dependencies:
-      '@aws-sdk/types': 3.667.0
+      '@aws-sdk/types': 3.723.0
       '@smithy/util-utf8': 2.3.0
       tslib: 2.7.0
 
-  '@aws-sdk/client-cognito-identity-provider@3.668.0':
+  '@aws-sdk/client-cognito-identity-provider@3.723.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/client-sso-oidc': 3.668.0(@aws-sdk/client-sts@3.668.0)
-      '@aws-sdk/client-sts': 3.668.0
-      '@aws-sdk/core': 3.667.0
-      '@aws-sdk/credential-provider-node': 3.668.0(@aws-sdk/client-sso-oidc@3.668.0(@aws-sdk/client-sts@3.668.0))(@aws-sdk/client-sts@3.668.0)
-      '@aws-sdk/middleware-host-header': 3.667.0
-      '@aws-sdk/middleware-logger': 3.667.0
-      '@aws-sdk/middleware-recursion-detection': 3.667.0
-      '@aws-sdk/middleware-user-agent': 3.668.0
-      '@aws-sdk/region-config-resolver': 3.667.0
-      '@aws-sdk/types': 3.667.0
-      '@aws-sdk/util-endpoints': 3.667.0
-      '@aws-sdk/util-user-agent-browser': 3.667.0
-      '@aws-sdk/util-user-agent-node': 3.668.0
-      '@smithy/config-resolver': 3.0.9
-      '@smithy/core': 2.4.8
-      '@smithy/fetch-http-handler': 3.2.9
-      '@smithy/hash-node': 3.0.7
-      '@smithy/invalid-dependency': 3.0.7
-      '@smithy/middleware-content-length': 3.0.9
-      '@smithy/middleware-endpoint': 3.1.4
-      '@smithy/middleware-retry': 3.0.23
-      '@smithy/middleware-serde': 3.0.7
-      '@smithy/middleware-stack': 3.0.7
-      '@smithy/node-config-provider': 3.1.8
-      '@smithy/node-http-handler': 3.2.4
-      '@smithy/protocol-http': 4.1.4
-      '@smithy/smithy-client': 3.4.0
-      '@smithy/types': 3.5.0
-      '@smithy/url-parser': 3.0.7
-      '@smithy/util-base64': 3.0.0
-      '@smithy/util-body-length-browser': 3.0.0
-      '@smithy/util-body-length-node': 3.0.0
-      '@smithy/util-defaults-mode-browser': 3.0.23
-      '@smithy/util-defaults-mode-node': 3.0.23
-      '@smithy/util-endpoints': 2.1.3
-      '@smithy/util-middleware': 3.0.7
-      '@smithy/util-retry': 3.0.7
-      '@smithy/util-utf8': 3.0.0
+      '@aws-sdk/client-sso-oidc': 3.723.0(@aws-sdk/client-sts@3.723.0)
+      '@aws-sdk/client-sts': 3.723.0
+      '@aws-sdk/core': 3.723.0
+      '@aws-sdk/credential-provider-node': 3.723.0(@aws-sdk/client-sso-oidc@3.723.0(@aws-sdk/client-sts@3.723.0))(@aws-sdk/client-sts@3.723.0)
+      '@aws-sdk/middleware-host-header': 3.723.0
+      '@aws-sdk/middleware-logger': 3.723.0
+      '@aws-sdk/middleware-recursion-detection': 3.723.0
+      '@aws-sdk/middleware-user-agent': 3.723.0
+      '@aws-sdk/region-config-resolver': 3.723.0
+      '@aws-sdk/types': 3.723.0
+      '@aws-sdk/util-endpoints': 3.723.0
+      '@aws-sdk/util-user-agent-browser': 3.723.0
+      '@aws-sdk/util-user-agent-node': 3.723.0
+      '@smithy/config-resolver': 4.0.0
+      '@smithy/core': 3.0.0
+      '@smithy/fetch-http-handler': 5.0.0
+      '@smithy/hash-node': 4.0.0
+      '@smithy/invalid-dependency': 4.0.0
+      '@smithy/middleware-content-length': 4.0.0
+      '@smithy/middleware-endpoint': 4.0.0
+      '@smithy/middleware-retry': 4.0.0
+      '@smithy/middleware-serde': 4.0.0
+      '@smithy/middleware-stack': 4.0.0
+      '@smithy/node-config-provider': 4.0.0
+      '@smithy/node-http-handler': 4.0.0
+      '@smithy/protocol-http': 5.0.0
+      '@smithy/smithy-client': 4.0.0
+      '@smithy/types': 4.0.0
+      '@smithy/url-parser': 4.0.0
+      '@smithy/util-base64': 4.0.0
+      '@smithy/util-body-length-browser': 4.0.0
+      '@smithy/util-body-length-node': 4.0.0
+      '@smithy/util-defaults-mode-browser': 4.0.0
+      '@smithy/util-defaults-mode-node': 4.0.0
+      '@smithy/util-endpoints': 3.0.0
+      '@smithy/util-middleware': 4.0.0
+      '@smithy/util-retry': 4.0.0
+      '@smithy/util-utf8': 4.0.0
       tslib: 2.7.0
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sso-oidc@3.668.0(@aws-sdk/client-sts@3.668.0)':
+  '@aws-sdk/client-sso-oidc@3.723.0(@aws-sdk/client-sts@3.723.0)':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/client-sts': 3.668.0
-      '@aws-sdk/core': 3.667.0
-      '@aws-sdk/credential-provider-node': 3.668.0(@aws-sdk/client-sso-oidc@3.668.0(@aws-sdk/client-sts@3.668.0))(@aws-sdk/client-sts@3.668.0)
-      '@aws-sdk/middleware-host-header': 3.667.0
-      '@aws-sdk/middleware-logger': 3.667.0
-      '@aws-sdk/middleware-recursion-detection': 3.667.0
-      '@aws-sdk/middleware-user-agent': 3.668.0
-      '@aws-sdk/region-config-resolver': 3.667.0
-      '@aws-sdk/types': 3.667.0
-      '@aws-sdk/util-endpoints': 3.667.0
-      '@aws-sdk/util-user-agent-browser': 3.667.0
-      '@aws-sdk/util-user-agent-node': 3.668.0
-      '@smithy/config-resolver': 3.0.9
-      '@smithy/core': 2.4.8
-      '@smithy/fetch-http-handler': 3.2.9
-      '@smithy/hash-node': 3.0.7
-      '@smithy/invalid-dependency': 3.0.7
-      '@smithy/middleware-content-length': 3.0.9
-      '@smithy/middleware-endpoint': 3.1.4
-      '@smithy/middleware-retry': 3.0.23
-      '@smithy/middleware-serde': 3.0.7
-      '@smithy/middleware-stack': 3.0.7
-      '@smithy/node-config-provider': 3.1.8
-      '@smithy/node-http-handler': 3.2.4
-      '@smithy/protocol-http': 4.1.4
-      '@smithy/smithy-client': 3.4.0
-      '@smithy/types': 3.5.0
-      '@smithy/url-parser': 3.0.7
-      '@smithy/util-base64': 3.0.0
-      '@smithy/util-body-length-browser': 3.0.0
-      '@smithy/util-body-length-node': 3.0.0
-      '@smithy/util-defaults-mode-browser': 3.0.23
-      '@smithy/util-defaults-mode-node': 3.0.23
-      '@smithy/util-endpoints': 2.1.3
-      '@smithy/util-middleware': 3.0.7
-      '@smithy/util-retry': 3.0.7
-      '@smithy/util-utf8': 3.0.0
+      '@aws-sdk/client-sts': 3.723.0
+      '@aws-sdk/core': 3.723.0
+      '@aws-sdk/credential-provider-node': 3.723.0(@aws-sdk/client-sso-oidc@3.723.0(@aws-sdk/client-sts@3.723.0))(@aws-sdk/client-sts@3.723.0)
+      '@aws-sdk/middleware-host-header': 3.723.0
+      '@aws-sdk/middleware-logger': 3.723.0
+      '@aws-sdk/middleware-recursion-detection': 3.723.0
+      '@aws-sdk/middleware-user-agent': 3.723.0
+      '@aws-sdk/region-config-resolver': 3.723.0
+      '@aws-sdk/types': 3.723.0
+      '@aws-sdk/util-endpoints': 3.723.0
+      '@aws-sdk/util-user-agent-browser': 3.723.0
+      '@aws-sdk/util-user-agent-node': 3.723.0
+      '@smithy/config-resolver': 4.0.0
+      '@smithy/core': 3.0.0
+      '@smithy/fetch-http-handler': 5.0.0
+      '@smithy/hash-node': 4.0.0
+      '@smithy/invalid-dependency': 4.0.0
+      '@smithy/middleware-content-length': 4.0.0
+      '@smithy/middleware-endpoint': 4.0.0
+      '@smithy/middleware-retry': 4.0.0
+      '@smithy/middleware-serde': 4.0.0
+      '@smithy/middleware-stack': 4.0.0
+      '@smithy/node-config-provider': 4.0.0
+      '@smithy/node-http-handler': 4.0.0
+      '@smithy/protocol-http': 5.0.0
+      '@smithy/smithy-client': 4.0.0
+      '@smithy/types': 4.0.0
+      '@smithy/url-parser': 4.0.0
+      '@smithy/util-base64': 4.0.0
+      '@smithy/util-body-length-browser': 4.0.0
+      '@smithy/util-body-length-node': 4.0.0
+      '@smithy/util-defaults-mode-browser': 4.0.0
+      '@smithy/util-defaults-mode-node': 4.0.0
+      '@smithy/util-endpoints': 3.0.0
+      '@smithy/util-middleware': 4.0.0
+      '@smithy/util-retry': 4.0.0
+      '@smithy/util-utf8': 4.0.0
       tslib: 2.7.0
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sso@3.668.0':
+  '@aws-sdk/client-sso@3.723.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.667.0
-      '@aws-sdk/middleware-host-header': 3.667.0
-      '@aws-sdk/middleware-logger': 3.667.0
-      '@aws-sdk/middleware-recursion-detection': 3.667.0
-      '@aws-sdk/middleware-user-agent': 3.668.0
-      '@aws-sdk/region-config-resolver': 3.667.0
-      '@aws-sdk/types': 3.667.0
-      '@aws-sdk/util-endpoints': 3.667.0
-      '@aws-sdk/util-user-agent-browser': 3.667.0
-      '@aws-sdk/util-user-agent-node': 3.668.0
-      '@smithy/config-resolver': 3.0.9
-      '@smithy/core': 2.4.8
-      '@smithy/fetch-http-handler': 3.2.9
-      '@smithy/hash-node': 3.0.7
-      '@smithy/invalid-dependency': 3.0.7
-      '@smithy/middleware-content-length': 3.0.9
-      '@smithy/middleware-endpoint': 3.1.4
-      '@smithy/middleware-retry': 3.0.23
-      '@smithy/middleware-serde': 3.0.7
-      '@smithy/middleware-stack': 3.0.7
-      '@smithy/node-config-provider': 3.1.8
-      '@smithy/node-http-handler': 3.2.4
-      '@smithy/protocol-http': 4.1.4
-      '@smithy/smithy-client': 3.4.0
-      '@smithy/types': 3.5.0
-      '@smithy/url-parser': 3.0.7
-      '@smithy/util-base64': 3.0.0
-      '@smithy/util-body-length-browser': 3.0.0
-      '@smithy/util-body-length-node': 3.0.0
-      '@smithy/util-defaults-mode-browser': 3.0.23
-      '@smithy/util-defaults-mode-node': 3.0.23
-      '@smithy/util-endpoints': 2.1.3
-      '@smithy/util-middleware': 3.0.7
-      '@smithy/util-retry': 3.0.7
-      '@smithy/util-utf8': 3.0.0
+      '@aws-sdk/core': 3.723.0
+      '@aws-sdk/middleware-host-header': 3.723.0
+      '@aws-sdk/middleware-logger': 3.723.0
+      '@aws-sdk/middleware-recursion-detection': 3.723.0
+      '@aws-sdk/middleware-user-agent': 3.723.0
+      '@aws-sdk/region-config-resolver': 3.723.0
+      '@aws-sdk/types': 3.723.0
+      '@aws-sdk/util-endpoints': 3.723.0
+      '@aws-sdk/util-user-agent-browser': 3.723.0
+      '@aws-sdk/util-user-agent-node': 3.723.0
+      '@smithy/config-resolver': 4.0.0
+      '@smithy/core': 3.0.0
+      '@smithy/fetch-http-handler': 5.0.0
+      '@smithy/hash-node': 4.0.0
+      '@smithy/invalid-dependency': 4.0.0
+      '@smithy/middleware-content-length': 4.0.0
+      '@smithy/middleware-endpoint': 4.0.0
+      '@smithy/middleware-retry': 4.0.0
+      '@smithy/middleware-serde': 4.0.0
+      '@smithy/middleware-stack': 4.0.0
+      '@smithy/node-config-provider': 4.0.0
+      '@smithy/node-http-handler': 4.0.0
+      '@smithy/protocol-http': 5.0.0
+      '@smithy/smithy-client': 4.0.0
+      '@smithy/types': 4.0.0
+      '@smithy/url-parser': 4.0.0
+      '@smithy/util-base64': 4.0.0
+      '@smithy/util-body-length-browser': 4.0.0
+      '@smithy/util-body-length-node': 4.0.0
+      '@smithy/util-defaults-mode-browser': 4.0.0
+      '@smithy/util-defaults-mode-node': 4.0.0
+      '@smithy/util-endpoints': 3.0.0
+      '@smithy/util-middleware': 4.0.0
+      '@smithy/util-retry': 4.0.0
+      '@smithy/util-utf8': 4.0.0
       tslib: 2.7.0
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sts@3.668.0':
+  '@aws-sdk/client-sts@3.723.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/client-sso-oidc': 3.668.0(@aws-sdk/client-sts@3.668.0)
-      '@aws-sdk/core': 3.667.0
-      '@aws-sdk/credential-provider-node': 3.668.0(@aws-sdk/client-sso-oidc@3.668.0(@aws-sdk/client-sts@3.668.0))(@aws-sdk/client-sts@3.668.0)
-      '@aws-sdk/middleware-host-header': 3.667.0
-      '@aws-sdk/middleware-logger': 3.667.0
-      '@aws-sdk/middleware-recursion-detection': 3.667.0
-      '@aws-sdk/middleware-user-agent': 3.668.0
-      '@aws-sdk/region-config-resolver': 3.667.0
-      '@aws-sdk/types': 3.667.0
-      '@aws-sdk/util-endpoints': 3.667.0
-      '@aws-sdk/util-user-agent-browser': 3.667.0
-      '@aws-sdk/util-user-agent-node': 3.668.0
-      '@smithy/config-resolver': 3.0.9
-      '@smithy/core': 2.4.8
-      '@smithy/fetch-http-handler': 3.2.9
-      '@smithy/hash-node': 3.0.7
-      '@smithy/invalid-dependency': 3.0.7
-      '@smithy/middleware-content-length': 3.0.9
-      '@smithy/middleware-endpoint': 3.1.4
-      '@smithy/middleware-retry': 3.0.23
-      '@smithy/middleware-serde': 3.0.7
-      '@smithy/middleware-stack': 3.0.7
-      '@smithy/node-config-provider': 3.1.8
-      '@smithy/node-http-handler': 3.2.4
-      '@smithy/protocol-http': 4.1.4
-      '@smithy/smithy-client': 3.4.0
-      '@smithy/types': 3.5.0
-      '@smithy/url-parser': 3.0.7
-      '@smithy/util-base64': 3.0.0
-      '@smithy/util-body-length-browser': 3.0.0
-      '@smithy/util-body-length-node': 3.0.0
-      '@smithy/util-defaults-mode-browser': 3.0.23
-      '@smithy/util-defaults-mode-node': 3.0.23
-      '@smithy/util-endpoints': 2.1.3
-      '@smithy/util-middleware': 3.0.7
-      '@smithy/util-retry': 3.0.7
-      '@smithy/util-utf8': 3.0.0
+      '@aws-sdk/client-sso-oidc': 3.723.0(@aws-sdk/client-sts@3.723.0)
+      '@aws-sdk/core': 3.723.0
+      '@aws-sdk/credential-provider-node': 3.723.0(@aws-sdk/client-sso-oidc@3.723.0(@aws-sdk/client-sts@3.723.0))(@aws-sdk/client-sts@3.723.0)
+      '@aws-sdk/middleware-host-header': 3.723.0
+      '@aws-sdk/middleware-logger': 3.723.0
+      '@aws-sdk/middleware-recursion-detection': 3.723.0
+      '@aws-sdk/middleware-user-agent': 3.723.0
+      '@aws-sdk/region-config-resolver': 3.723.0
+      '@aws-sdk/types': 3.723.0
+      '@aws-sdk/util-endpoints': 3.723.0
+      '@aws-sdk/util-user-agent-browser': 3.723.0
+      '@aws-sdk/util-user-agent-node': 3.723.0
+      '@smithy/config-resolver': 4.0.0
+      '@smithy/core': 3.0.0
+      '@smithy/fetch-http-handler': 5.0.0
+      '@smithy/hash-node': 4.0.0
+      '@smithy/invalid-dependency': 4.0.0
+      '@smithy/middleware-content-length': 4.0.0
+      '@smithy/middleware-endpoint': 4.0.0
+      '@smithy/middleware-retry': 4.0.0
+      '@smithy/middleware-serde': 4.0.0
+      '@smithy/middleware-stack': 4.0.0
+      '@smithy/node-config-provider': 4.0.0
+      '@smithy/node-http-handler': 4.0.0
+      '@smithy/protocol-http': 5.0.0
+      '@smithy/smithy-client': 4.0.0
+      '@smithy/types': 4.0.0
+      '@smithy/url-parser': 4.0.0
+      '@smithy/util-base64': 4.0.0
+      '@smithy/util-body-length-browser': 4.0.0
+      '@smithy/util-body-length-node': 4.0.0
+      '@smithy/util-defaults-mode-browser': 4.0.0
+      '@smithy/util-defaults-mode-node': 4.0.0
+      '@smithy/util-endpoints': 3.0.0
+      '@smithy/util-middleware': 4.0.0
+      '@smithy/util-retry': 4.0.0
+      '@smithy/util-utf8': 4.0.0
       tslib: 2.7.0
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/core@3.667.0':
+  '@aws-sdk/core@3.723.0':
     dependencies:
-      '@aws-sdk/types': 3.667.0
-      '@smithy/core': 2.4.8
-      '@smithy/node-config-provider': 3.1.8
-      '@smithy/property-provider': 3.1.7
-      '@smithy/protocol-http': 4.1.4
-      '@smithy/signature-v4': 4.2.0
-      '@smithy/smithy-client': 3.4.0
-      '@smithy/types': 3.5.0
-      '@smithy/util-middleware': 3.0.7
+      '@aws-sdk/types': 3.723.0
+      '@smithy/core': 3.0.0
+      '@smithy/node-config-provider': 4.0.0
+      '@smithy/property-provider': 4.0.0
+      '@smithy/protocol-http': 5.0.0
+      '@smithy/signature-v4': 5.0.0
+      '@smithy/smithy-client': 4.0.0
+      '@smithy/types': 4.0.0
+      '@smithy/util-middleware': 4.0.0
       fast-xml-parser: 4.4.1
       tslib: 2.7.0
 
-  '@aws-sdk/credential-provider-env@3.667.0':
+  '@aws-sdk/credential-provider-env@3.723.0':
     dependencies:
-      '@aws-sdk/core': 3.667.0
-      '@aws-sdk/types': 3.667.0
-      '@smithy/property-provider': 3.1.7
-      '@smithy/types': 3.5.0
+      '@aws-sdk/core': 3.723.0
+      '@aws-sdk/types': 3.723.0
+      '@smithy/property-provider': 4.0.0
+      '@smithy/types': 4.0.0
       tslib: 2.7.0
 
-  '@aws-sdk/credential-provider-http@3.667.0':
+  '@aws-sdk/credential-provider-http@3.723.0':
     dependencies:
-      '@aws-sdk/core': 3.667.0
-      '@aws-sdk/types': 3.667.0
-      '@smithy/fetch-http-handler': 3.2.9
-      '@smithy/node-http-handler': 3.2.4
-      '@smithy/property-provider': 3.1.7
-      '@smithy/protocol-http': 4.1.4
-      '@smithy/smithy-client': 3.4.0
-      '@smithy/types': 3.5.0
-      '@smithy/util-stream': 3.1.9
+      '@aws-sdk/core': 3.723.0
+      '@aws-sdk/types': 3.723.0
+      '@smithy/fetch-http-handler': 5.0.0
+      '@smithy/node-http-handler': 4.0.0
+      '@smithy/property-provider': 4.0.0
+      '@smithy/protocol-http': 5.0.0
+      '@smithy/smithy-client': 4.0.0
+      '@smithy/types': 4.0.0
+      '@smithy/util-stream': 4.0.0
       tslib: 2.7.0
 
-  '@aws-sdk/credential-provider-ini@3.668.0(@aws-sdk/client-sso-oidc@3.668.0(@aws-sdk/client-sts@3.668.0))(@aws-sdk/client-sts@3.668.0)':
+  '@aws-sdk/credential-provider-ini@3.723.0(@aws-sdk/client-sso-oidc@3.723.0(@aws-sdk/client-sts@3.723.0))(@aws-sdk/client-sts@3.723.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.668.0
-      '@aws-sdk/core': 3.667.0
-      '@aws-sdk/credential-provider-env': 3.667.0
-      '@aws-sdk/credential-provider-http': 3.667.0
-      '@aws-sdk/credential-provider-process': 3.667.0
-      '@aws-sdk/credential-provider-sso': 3.668.0(@aws-sdk/client-sso-oidc@3.668.0(@aws-sdk/client-sts@3.668.0))
-      '@aws-sdk/credential-provider-web-identity': 3.667.0(@aws-sdk/client-sts@3.668.0)
-      '@aws-sdk/types': 3.667.0
-      '@smithy/credential-provider-imds': 3.2.4
-      '@smithy/property-provider': 3.1.7
-      '@smithy/shared-ini-file-loader': 3.1.8
-      '@smithy/types': 3.5.0
+      '@aws-sdk/client-sts': 3.723.0
+      '@aws-sdk/core': 3.723.0
+      '@aws-sdk/credential-provider-env': 3.723.0
+      '@aws-sdk/credential-provider-http': 3.723.0
+      '@aws-sdk/credential-provider-process': 3.723.0
+      '@aws-sdk/credential-provider-sso': 3.723.0(@aws-sdk/client-sso-oidc@3.723.0(@aws-sdk/client-sts@3.723.0))
+      '@aws-sdk/credential-provider-web-identity': 3.723.0(@aws-sdk/client-sts@3.723.0)
+      '@aws-sdk/types': 3.723.0
+      '@smithy/credential-provider-imds': 4.0.0
+      '@smithy/property-provider': 4.0.0
+      '@smithy/shared-ini-file-loader': 4.0.0
+      '@smithy/types': 4.0.0
       tslib: 2.7.0
     transitivePeerDependencies:
       - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
-  '@aws-sdk/credential-provider-node@3.668.0(@aws-sdk/client-sso-oidc@3.668.0(@aws-sdk/client-sts@3.668.0))(@aws-sdk/client-sts@3.668.0)':
+  '@aws-sdk/credential-provider-node@3.723.0(@aws-sdk/client-sso-oidc@3.723.0(@aws-sdk/client-sts@3.723.0))(@aws-sdk/client-sts@3.723.0)':
     dependencies:
-      '@aws-sdk/credential-provider-env': 3.667.0
-      '@aws-sdk/credential-provider-http': 3.667.0
-      '@aws-sdk/credential-provider-ini': 3.668.0(@aws-sdk/client-sso-oidc@3.668.0(@aws-sdk/client-sts@3.668.0))(@aws-sdk/client-sts@3.668.0)
-      '@aws-sdk/credential-provider-process': 3.667.0
-      '@aws-sdk/credential-provider-sso': 3.668.0(@aws-sdk/client-sso-oidc@3.668.0(@aws-sdk/client-sts@3.668.0))
-      '@aws-sdk/credential-provider-web-identity': 3.667.0(@aws-sdk/client-sts@3.668.0)
-      '@aws-sdk/types': 3.667.0
-      '@smithy/credential-provider-imds': 3.2.4
-      '@smithy/property-provider': 3.1.7
-      '@smithy/shared-ini-file-loader': 3.1.8
-      '@smithy/types': 3.5.0
+      '@aws-sdk/credential-provider-env': 3.723.0
+      '@aws-sdk/credential-provider-http': 3.723.0
+      '@aws-sdk/credential-provider-ini': 3.723.0(@aws-sdk/client-sso-oidc@3.723.0(@aws-sdk/client-sts@3.723.0))(@aws-sdk/client-sts@3.723.0)
+      '@aws-sdk/credential-provider-process': 3.723.0
+      '@aws-sdk/credential-provider-sso': 3.723.0(@aws-sdk/client-sso-oidc@3.723.0(@aws-sdk/client-sts@3.723.0))
+      '@aws-sdk/credential-provider-web-identity': 3.723.0(@aws-sdk/client-sts@3.723.0)
+      '@aws-sdk/types': 3.723.0
+      '@smithy/credential-provider-imds': 4.0.0
+      '@smithy/property-provider': 4.0.0
+      '@smithy/shared-ini-file-loader': 4.0.0
+      '@smithy/types': 4.0.0
       tslib: 2.7.0
     transitivePeerDependencies:
       - '@aws-sdk/client-sso-oidc'
       - '@aws-sdk/client-sts'
       - aws-crt
 
-  '@aws-sdk/credential-provider-process@3.667.0':
+  '@aws-sdk/credential-provider-process@3.723.0':
     dependencies:
-      '@aws-sdk/core': 3.667.0
-      '@aws-sdk/types': 3.667.0
-      '@smithy/property-provider': 3.1.7
-      '@smithy/shared-ini-file-loader': 3.1.8
-      '@smithy/types': 3.5.0
+      '@aws-sdk/core': 3.723.0
+      '@aws-sdk/types': 3.723.0
+      '@smithy/property-provider': 4.0.0
+      '@smithy/shared-ini-file-loader': 4.0.0
+      '@smithy/types': 4.0.0
       tslib: 2.7.0
 
-  '@aws-sdk/credential-provider-sso@3.668.0(@aws-sdk/client-sso-oidc@3.668.0(@aws-sdk/client-sts@3.668.0))':
+  '@aws-sdk/credential-provider-sso@3.723.0(@aws-sdk/client-sso-oidc@3.723.0(@aws-sdk/client-sts@3.723.0))':
     dependencies:
-      '@aws-sdk/client-sso': 3.668.0
-      '@aws-sdk/core': 3.667.0
-      '@aws-sdk/token-providers': 3.667.0(@aws-sdk/client-sso-oidc@3.668.0(@aws-sdk/client-sts@3.668.0))
-      '@aws-sdk/types': 3.667.0
-      '@smithy/property-provider': 3.1.7
-      '@smithy/shared-ini-file-loader': 3.1.8
-      '@smithy/types': 3.5.0
+      '@aws-sdk/client-sso': 3.723.0
+      '@aws-sdk/core': 3.723.0
+      '@aws-sdk/token-providers': 3.723.0(@aws-sdk/client-sso-oidc@3.723.0(@aws-sdk/client-sts@3.723.0))
+      '@aws-sdk/types': 3.723.0
+      '@smithy/property-provider': 4.0.0
+      '@smithy/shared-ini-file-loader': 4.0.0
+      '@smithy/types': 4.0.0
       tslib: 2.7.0
     transitivePeerDependencies:
       - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
-  '@aws-sdk/credential-provider-web-identity@3.667.0(@aws-sdk/client-sts@3.668.0)':
+  '@aws-sdk/credential-provider-web-identity@3.723.0(@aws-sdk/client-sts@3.723.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.668.0
-      '@aws-sdk/core': 3.667.0
-      '@aws-sdk/types': 3.667.0
-      '@smithy/property-provider': 3.1.7
-      '@smithy/types': 3.5.0
+      '@aws-sdk/client-sts': 3.723.0
+      '@aws-sdk/core': 3.723.0
+      '@aws-sdk/types': 3.723.0
+      '@smithy/property-provider': 4.0.0
+      '@smithy/types': 4.0.0
       tslib: 2.7.0
 
-  '@aws-sdk/middleware-host-header@3.667.0':
+  '@aws-sdk/middleware-host-header@3.723.0':
     dependencies:
-      '@aws-sdk/types': 3.667.0
-      '@smithy/protocol-http': 4.1.4
-      '@smithy/types': 3.5.0
+      '@aws-sdk/types': 3.723.0
+      '@smithy/protocol-http': 5.0.0
+      '@smithy/types': 4.0.0
       tslib: 2.7.0
 
-  '@aws-sdk/middleware-logger@3.667.0':
+  '@aws-sdk/middleware-logger@3.723.0':
     dependencies:
-      '@aws-sdk/types': 3.667.0
-      '@smithy/types': 3.5.0
+      '@aws-sdk/types': 3.723.0
+      '@smithy/types': 4.0.0
       tslib: 2.7.0
 
-  '@aws-sdk/middleware-recursion-detection@3.667.0':
+  '@aws-sdk/middleware-recursion-detection@3.723.0':
     dependencies:
-      '@aws-sdk/types': 3.667.0
-      '@smithy/protocol-http': 4.1.4
-      '@smithy/types': 3.5.0
+      '@aws-sdk/types': 3.723.0
+      '@smithy/protocol-http': 5.0.0
+      '@smithy/types': 4.0.0
       tslib: 2.7.0
 
-  '@aws-sdk/middleware-user-agent@3.668.0':
+  '@aws-sdk/middleware-user-agent@3.723.0':
     dependencies:
-      '@aws-sdk/core': 3.667.0
-      '@aws-sdk/types': 3.667.0
-      '@aws-sdk/util-endpoints': 3.667.0
-      '@smithy/core': 2.4.8
-      '@smithy/protocol-http': 4.1.4
-      '@smithy/types': 3.5.0
+      '@aws-sdk/core': 3.723.0
+      '@aws-sdk/types': 3.723.0
+      '@aws-sdk/util-endpoints': 3.723.0
+      '@smithy/core': 3.0.0
+      '@smithy/protocol-http': 5.0.0
+      '@smithy/types': 4.0.0
       tslib: 2.7.0
 
-  '@aws-sdk/region-config-resolver@3.667.0':
+  '@aws-sdk/region-config-resolver@3.723.0':
     dependencies:
-      '@aws-sdk/types': 3.667.0
-      '@smithy/node-config-provider': 3.1.8
-      '@smithy/types': 3.5.0
-      '@smithy/util-config-provider': 3.0.0
-      '@smithy/util-middleware': 3.0.7
+      '@aws-sdk/types': 3.723.0
+      '@smithy/node-config-provider': 4.0.0
+      '@smithy/types': 4.0.0
+      '@smithy/util-config-provider': 4.0.0
+      '@smithy/util-middleware': 4.0.0
       tslib: 2.7.0
 
-  '@aws-sdk/token-providers@3.667.0(@aws-sdk/client-sso-oidc@3.668.0(@aws-sdk/client-sts@3.668.0))':
+  '@aws-sdk/token-providers@3.723.0(@aws-sdk/client-sso-oidc@3.723.0(@aws-sdk/client-sts@3.723.0))':
     dependencies:
-      '@aws-sdk/client-sso-oidc': 3.668.0(@aws-sdk/client-sts@3.668.0)
-      '@aws-sdk/types': 3.667.0
-      '@smithy/property-provider': 3.1.7
-      '@smithy/shared-ini-file-loader': 3.1.8
-      '@smithy/types': 3.5.0
+      '@aws-sdk/client-sso-oidc': 3.723.0(@aws-sdk/client-sts@3.723.0)
+      '@aws-sdk/types': 3.723.0
+      '@smithy/property-provider': 4.0.0
+      '@smithy/shared-ini-file-loader': 4.0.0
+      '@smithy/types': 4.0.0
       tslib: 2.7.0
 
-  '@aws-sdk/types@3.667.0':
+  '@aws-sdk/types@3.723.0':
     dependencies:
-      '@smithy/types': 3.5.0
+      '@smithy/types': 4.0.0
       tslib: 2.7.0
 
-  '@aws-sdk/util-endpoints@3.667.0':
+  '@aws-sdk/util-endpoints@3.723.0':
     dependencies:
-      '@aws-sdk/types': 3.667.0
-      '@smithy/types': 3.5.0
-      '@smithy/util-endpoints': 2.1.3
+      '@aws-sdk/types': 3.723.0
+      '@smithy/types': 4.0.0
+      '@smithy/util-endpoints': 3.0.0
       tslib: 2.7.0
 
-  '@aws-sdk/util-locate-window@3.568.0':
+  '@aws-sdk/util-locate-window@3.723.0':
     dependencies:
       tslib: 2.7.0
 
-  '@aws-sdk/util-user-agent-browser@3.667.0':
+  '@aws-sdk/util-user-agent-browser@3.723.0':
     dependencies:
-      '@aws-sdk/types': 3.667.0
-      '@smithy/types': 3.5.0
+      '@aws-sdk/types': 3.723.0
+      '@smithy/types': 4.0.0
       bowser: 2.11.0
       tslib: 2.7.0
 
-  '@aws-sdk/util-user-agent-node@3.668.0':
+  '@aws-sdk/util-user-agent-node@3.723.0':
     dependencies:
-      '@aws-sdk/middleware-user-agent': 3.668.0
-      '@aws-sdk/types': 3.667.0
-      '@smithy/node-config-provider': 3.1.8
-      '@smithy/types': 3.5.0
+      '@aws-sdk/middleware-user-agent': 3.723.0
+      '@aws-sdk/types': 3.723.0
+      '@smithy/node-config-provider': 4.0.0
+      '@smithy/types': 4.0.0
       tslib: 2.7.0
 
   '@babel/code-frame@7.25.7':
@@ -3999,7 +4003,7 @@ snapshots:
 
   '@databeat/tracker@0.9.3':
     dependencies:
-      '@noble/hashes': 1.6.1
+      '@noble/hashes': 1.7.0
 
   '@emotion/hash@0.9.2': {}
 
@@ -4242,7 +4246,7 @@ snapshots:
 
   '@noble/hashes@1.3.2': {}
 
-  '@noble/hashes@1.6.1': {}
+  '@noble/hashes@1.7.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -4838,192 +4842,192 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.24.0':
     optional: true
 
-  '@smithy/abort-controller@3.1.5':
+  '@smithy/abort-controller@4.0.0':
     dependencies:
-      '@smithy/types': 3.5.0
+      '@smithy/types': 4.0.0
       tslib: 2.7.0
 
-  '@smithy/config-resolver@3.0.9':
+  '@smithy/config-resolver@4.0.0':
     dependencies:
-      '@smithy/node-config-provider': 3.1.8
-      '@smithy/types': 3.5.0
-      '@smithy/util-config-provider': 3.0.0
-      '@smithy/util-middleware': 3.0.7
+      '@smithy/node-config-provider': 4.0.0
+      '@smithy/types': 4.0.0
+      '@smithy/util-config-provider': 4.0.0
+      '@smithy/util-middleware': 4.0.0
       tslib: 2.7.0
 
-  '@smithy/core@2.4.8':
+  '@smithy/core@3.0.0':
     dependencies:
-      '@smithy/middleware-endpoint': 3.1.4
-      '@smithy/middleware-retry': 3.0.23
-      '@smithy/middleware-serde': 3.0.7
-      '@smithy/protocol-http': 4.1.4
-      '@smithy/smithy-client': 3.4.0
-      '@smithy/types': 3.5.0
-      '@smithy/util-body-length-browser': 3.0.0
-      '@smithy/util-middleware': 3.0.7
-      '@smithy/util-utf8': 3.0.0
+      '@smithy/middleware-serde': 4.0.0
+      '@smithy/protocol-http': 5.0.0
+      '@smithy/types': 4.0.0
+      '@smithy/util-body-length-browser': 4.0.0
+      '@smithy/util-middleware': 4.0.0
+      '@smithy/util-stream': 4.0.0
+      '@smithy/util-utf8': 4.0.0
       tslib: 2.7.0
 
-  '@smithy/credential-provider-imds@3.2.4':
+  '@smithy/credential-provider-imds@4.0.0':
     dependencies:
-      '@smithy/node-config-provider': 3.1.8
-      '@smithy/property-provider': 3.1.7
-      '@smithy/types': 3.5.0
-      '@smithy/url-parser': 3.0.7
+      '@smithy/node-config-provider': 4.0.0
+      '@smithy/property-provider': 4.0.0
+      '@smithy/types': 4.0.0
+      '@smithy/url-parser': 4.0.0
       tslib: 2.7.0
 
-  '@smithy/fetch-http-handler@3.2.9':
+  '@smithy/fetch-http-handler@5.0.0':
     dependencies:
-      '@smithy/protocol-http': 4.1.4
-      '@smithy/querystring-builder': 3.0.7
-      '@smithy/types': 3.5.0
-      '@smithy/util-base64': 3.0.0
+      '@smithy/protocol-http': 5.0.0
+      '@smithy/querystring-builder': 4.0.0
+      '@smithy/types': 4.0.0
+      '@smithy/util-base64': 4.0.0
       tslib: 2.7.0
 
-  '@smithy/hash-node@3.0.7':
+  '@smithy/hash-node@4.0.0':
     dependencies:
-      '@smithy/types': 3.5.0
-      '@smithy/util-buffer-from': 3.0.0
-      '@smithy/util-utf8': 3.0.0
+      '@smithy/types': 4.0.0
+      '@smithy/util-buffer-from': 4.0.0
+      '@smithy/util-utf8': 4.0.0
       tslib: 2.7.0
 
-  '@smithy/invalid-dependency@3.0.7':
+  '@smithy/invalid-dependency@4.0.0':
     dependencies:
-      '@smithy/types': 3.5.0
+      '@smithy/types': 4.0.0
       tslib: 2.7.0
 
   '@smithy/is-array-buffer@2.2.0':
     dependencies:
       tslib: 2.7.0
 
-  '@smithy/is-array-buffer@3.0.0':
+  '@smithy/is-array-buffer@4.0.0':
     dependencies:
       tslib: 2.7.0
 
-  '@smithy/middleware-content-length@3.0.9':
+  '@smithy/middleware-content-length@4.0.0':
     dependencies:
-      '@smithy/protocol-http': 4.1.4
-      '@smithy/types': 3.5.0
+      '@smithy/protocol-http': 5.0.0
+      '@smithy/types': 4.0.0
       tslib: 2.7.0
 
-  '@smithy/middleware-endpoint@3.1.4':
+  '@smithy/middleware-endpoint@4.0.0':
     dependencies:
-      '@smithy/middleware-serde': 3.0.7
-      '@smithy/node-config-provider': 3.1.8
-      '@smithy/shared-ini-file-loader': 3.1.8
-      '@smithy/types': 3.5.0
-      '@smithy/url-parser': 3.0.7
-      '@smithy/util-middleware': 3.0.7
+      '@smithy/core': 3.0.0
+      '@smithy/middleware-serde': 4.0.0
+      '@smithy/node-config-provider': 4.0.0
+      '@smithy/shared-ini-file-loader': 4.0.0
+      '@smithy/types': 4.0.0
+      '@smithy/url-parser': 4.0.0
+      '@smithy/util-middleware': 4.0.0
       tslib: 2.7.0
 
-  '@smithy/middleware-retry@3.0.23':
+  '@smithy/middleware-retry@4.0.0':
     dependencies:
-      '@smithy/node-config-provider': 3.1.8
-      '@smithy/protocol-http': 4.1.4
-      '@smithy/service-error-classification': 3.0.7
-      '@smithy/smithy-client': 3.4.0
-      '@smithy/types': 3.5.0
-      '@smithy/util-middleware': 3.0.7
-      '@smithy/util-retry': 3.0.7
+      '@smithy/node-config-provider': 4.0.0
+      '@smithy/protocol-http': 5.0.0
+      '@smithy/service-error-classification': 4.0.0
+      '@smithy/smithy-client': 4.0.0
+      '@smithy/types': 4.0.0
+      '@smithy/util-middleware': 4.0.0
+      '@smithy/util-retry': 4.0.0
       tslib: 2.7.0
       uuid: 9.0.1
 
-  '@smithy/middleware-serde@3.0.7':
+  '@smithy/middleware-serde@4.0.0':
     dependencies:
-      '@smithy/types': 3.5.0
+      '@smithy/types': 4.0.0
       tslib: 2.7.0
 
-  '@smithy/middleware-stack@3.0.7':
+  '@smithy/middleware-stack@4.0.0':
     dependencies:
-      '@smithy/types': 3.5.0
+      '@smithy/types': 4.0.0
       tslib: 2.7.0
 
-  '@smithy/node-config-provider@3.1.8':
+  '@smithy/node-config-provider@4.0.0':
     dependencies:
-      '@smithy/property-provider': 3.1.7
-      '@smithy/shared-ini-file-loader': 3.1.8
-      '@smithy/types': 3.5.0
+      '@smithy/property-provider': 4.0.0
+      '@smithy/shared-ini-file-loader': 4.0.0
+      '@smithy/types': 4.0.0
       tslib: 2.7.0
 
-  '@smithy/node-http-handler@3.2.4':
+  '@smithy/node-http-handler@4.0.0':
     dependencies:
-      '@smithy/abort-controller': 3.1.5
-      '@smithy/protocol-http': 4.1.4
-      '@smithy/querystring-builder': 3.0.7
-      '@smithy/types': 3.5.0
+      '@smithy/abort-controller': 4.0.0
+      '@smithy/protocol-http': 5.0.0
+      '@smithy/querystring-builder': 4.0.0
+      '@smithy/types': 4.0.0
       tslib: 2.7.0
 
-  '@smithy/property-provider@3.1.7':
+  '@smithy/property-provider@4.0.0':
     dependencies:
-      '@smithy/types': 3.5.0
+      '@smithy/types': 4.0.0
       tslib: 2.7.0
 
-  '@smithy/protocol-http@4.1.4':
+  '@smithy/protocol-http@5.0.0':
     dependencies:
-      '@smithy/types': 3.5.0
+      '@smithy/types': 4.0.0
       tslib: 2.7.0
 
-  '@smithy/querystring-builder@3.0.7':
+  '@smithy/querystring-builder@4.0.0':
     dependencies:
-      '@smithy/types': 3.5.0
-      '@smithy/util-uri-escape': 3.0.0
+      '@smithy/types': 4.0.0
+      '@smithy/util-uri-escape': 4.0.0
       tslib: 2.7.0
 
-  '@smithy/querystring-parser@3.0.7':
+  '@smithy/querystring-parser@4.0.0':
     dependencies:
-      '@smithy/types': 3.5.0
+      '@smithy/types': 4.0.0
       tslib: 2.7.0
 
-  '@smithy/service-error-classification@3.0.7':
+  '@smithy/service-error-classification@4.0.0':
     dependencies:
-      '@smithy/types': 3.5.0
+      '@smithy/types': 4.0.0
 
-  '@smithy/shared-ini-file-loader@3.1.8':
+  '@smithy/shared-ini-file-loader@4.0.0':
     dependencies:
-      '@smithy/types': 3.5.0
+      '@smithy/types': 4.0.0
       tslib: 2.7.0
 
-  '@smithy/signature-v4@4.2.0':
+  '@smithy/signature-v4@5.0.0':
     dependencies:
-      '@smithy/is-array-buffer': 3.0.0
-      '@smithy/protocol-http': 4.1.4
-      '@smithy/types': 3.5.0
-      '@smithy/util-hex-encoding': 3.0.0
-      '@smithy/util-middleware': 3.0.7
-      '@smithy/util-uri-escape': 3.0.0
-      '@smithy/util-utf8': 3.0.0
+      '@smithy/is-array-buffer': 4.0.0
+      '@smithy/protocol-http': 5.0.0
+      '@smithy/types': 4.0.0
+      '@smithy/util-hex-encoding': 4.0.0
+      '@smithy/util-middleware': 4.0.0
+      '@smithy/util-uri-escape': 4.0.0
+      '@smithy/util-utf8': 4.0.0
       tslib: 2.7.0
 
-  '@smithy/smithy-client@3.4.0':
+  '@smithy/smithy-client@4.0.0':
     dependencies:
-      '@smithy/middleware-endpoint': 3.1.4
-      '@smithy/middleware-stack': 3.0.7
-      '@smithy/protocol-http': 4.1.4
-      '@smithy/types': 3.5.0
-      '@smithy/util-stream': 3.1.9
+      '@smithy/core': 3.0.0
+      '@smithy/middleware-endpoint': 4.0.0
+      '@smithy/middleware-stack': 4.0.0
+      '@smithy/protocol-http': 5.0.0
+      '@smithy/types': 4.0.0
+      '@smithy/util-stream': 4.0.0
       tslib: 2.7.0
 
-  '@smithy/types@3.5.0':
-    dependencies:
-      tslib: 2.7.0
-
-  '@smithy/url-parser@3.0.7':
-    dependencies:
-      '@smithy/querystring-parser': 3.0.7
-      '@smithy/types': 3.5.0
-      tslib: 2.7.0
-
-  '@smithy/util-base64@3.0.0':
-    dependencies:
-      '@smithy/util-buffer-from': 3.0.0
-      '@smithy/util-utf8': 3.0.0
-      tslib: 2.7.0
-
-  '@smithy/util-body-length-browser@3.0.0':
+  '@smithy/types@4.0.0':
     dependencies:
       tslib: 2.7.0
 
-  '@smithy/util-body-length-node@3.0.0':
+  '@smithy/url-parser@4.0.0':
+    dependencies:
+      '@smithy/querystring-parser': 4.0.0
+      '@smithy/types': 4.0.0
+      tslib: 2.7.0
+
+  '@smithy/util-base64@4.0.0':
+    dependencies:
+      '@smithy/util-buffer-from': 4.0.0
+      '@smithy/util-utf8': 4.0.0
+      tslib: 2.7.0
+
+  '@smithy/util-body-length-browser@4.0.0':
+    dependencies:
+      tslib: 2.7.0
+
+  '@smithy/util-body-length-node@4.0.0':
     dependencies:
       tslib: 2.7.0
 
@@ -5032,66 +5036,66 @@ snapshots:
       '@smithy/is-array-buffer': 2.2.0
       tslib: 2.7.0
 
-  '@smithy/util-buffer-from@3.0.0':
+  '@smithy/util-buffer-from@4.0.0':
     dependencies:
-      '@smithy/is-array-buffer': 3.0.0
+      '@smithy/is-array-buffer': 4.0.0
       tslib: 2.7.0
 
-  '@smithy/util-config-provider@3.0.0':
+  '@smithy/util-config-provider@4.0.0':
     dependencies:
       tslib: 2.7.0
 
-  '@smithy/util-defaults-mode-browser@3.0.23':
+  '@smithy/util-defaults-mode-browser@4.0.0':
     dependencies:
-      '@smithy/property-provider': 3.1.7
-      '@smithy/smithy-client': 3.4.0
-      '@smithy/types': 3.5.0
+      '@smithy/property-provider': 4.0.0
+      '@smithy/smithy-client': 4.0.0
+      '@smithy/types': 4.0.0
       bowser: 2.11.0
       tslib: 2.7.0
 
-  '@smithy/util-defaults-mode-node@3.0.23':
+  '@smithy/util-defaults-mode-node@4.0.0':
     dependencies:
-      '@smithy/config-resolver': 3.0.9
-      '@smithy/credential-provider-imds': 3.2.4
-      '@smithy/node-config-provider': 3.1.8
-      '@smithy/property-provider': 3.1.7
-      '@smithy/smithy-client': 3.4.0
-      '@smithy/types': 3.5.0
+      '@smithy/config-resolver': 4.0.0
+      '@smithy/credential-provider-imds': 4.0.0
+      '@smithy/node-config-provider': 4.0.0
+      '@smithy/property-provider': 4.0.0
+      '@smithy/smithy-client': 4.0.0
+      '@smithy/types': 4.0.0
       tslib: 2.7.0
 
-  '@smithy/util-endpoints@2.1.3':
+  '@smithy/util-endpoints@3.0.0':
     dependencies:
-      '@smithy/node-config-provider': 3.1.8
-      '@smithy/types': 3.5.0
+      '@smithy/node-config-provider': 4.0.0
+      '@smithy/types': 4.0.0
       tslib: 2.7.0
 
-  '@smithy/util-hex-encoding@3.0.0':
+  '@smithy/util-hex-encoding@4.0.0':
     dependencies:
       tslib: 2.7.0
 
-  '@smithy/util-middleware@3.0.7':
+  '@smithy/util-middleware@4.0.0':
     dependencies:
-      '@smithy/types': 3.5.0
+      '@smithy/types': 4.0.0
       tslib: 2.7.0
 
-  '@smithy/util-retry@3.0.7':
+  '@smithy/util-retry@4.0.0':
     dependencies:
-      '@smithy/service-error-classification': 3.0.7
-      '@smithy/types': 3.5.0
+      '@smithy/service-error-classification': 4.0.0
+      '@smithy/types': 4.0.0
       tslib: 2.7.0
 
-  '@smithy/util-stream@3.1.9':
+  '@smithy/util-stream@4.0.0':
     dependencies:
-      '@smithy/fetch-http-handler': 3.2.9
-      '@smithy/node-http-handler': 3.2.4
-      '@smithy/types': 3.5.0
-      '@smithy/util-base64': 3.0.0
-      '@smithy/util-buffer-from': 3.0.0
-      '@smithy/util-hex-encoding': 3.0.0
-      '@smithy/util-utf8': 3.0.0
+      '@smithy/fetch-http-handler': 5.0.0
+      '@smithy/node-http-handler': 4.0.0
+      '@smithy/types': 4.0.0
+      '@smithy/util-base64': 4.0.0
+      '@smithy/util-buffer-from': 4.0.0
+      '@smithy/util-hex-encoding': 4.0.0
+      '@smithy/util-utf8': 4.0.0
       tslib: 2.7.0
 
-  '@smithy/util-uri-escape@3.0.0':
+  '@smithy/util-uri-escape@4.0.0':
     dependencies:
       tslib: 2.7.0
 
@@ -5100,9 +5104,9 @@ snapshots:
       '@smithy/util-buffer-from': 2.2.0
       tslib: 2.7.0
 
-  '@smithy/util-utf8@3.0.0':
+  '@smithy/util-utf8@4.0.0':
     dependencies:
-      '@smithy/util-buffer-from': 3.0.0
+      '@smithy/util-buffer-from': 4.0.0
       tslib: 2.7.0
 
   '@stytch/core@2.28.0':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,20 +9,20 @@ importers:
   .:
     dependencies:
       0xsequence:
-        specifier: 2.0.17
-        version: 2.0.17(ethers@6.13.3)
+        specifier: 2.1.3
+        version: 2.1.3(ethers@6.13.3)
       '@0xsequence/design-system':
         specifier: 1.7.8
         version: 1.7.8(@types/react-dom@18.3.0)(@types/react@18.3.11)(framer-motion@11.11.7(@emotion/is-prop-valid@1.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@0xsequence/indexer':
-        specifier: 2.0.17
-        version: 2.0.17
+        specifier: 2.1.3
+        version: 2.1.3
       '@0xsequence/network':
-        specifier: 2.0.17
-        version: 2.0.17(ethers@6.13.3)
+        specifier: 2.1.3
+        version: 2.1.3(ethers@6.13.3)
       '@0xsequence/waas':
-        specifier: 2.0.17
-        version: 2.0.17(ethers@6.13.3)
+        specifier: 2.1.3
+        version: 2.1.3(ethers@6.13.3)
       '@react-oauth/google':
         specifier: ^0.12.1
         version: 0.12.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -123,29 +123,29 @@ importers:
 
 packages:
 
-  0xsequence@2.0.17:
-    resolution: {integrity: sha512-xN5rvUxLSWDDQ7l3x3xzvQWcykUqrf22pwlBpv2T9X2c1v61vJVw1irmn8q+6yVSNgfXjZQNP1LbpJxeFnY/XQ==}
+  0xsequence@2.1.3:
+    resolution: {integrity: sha512-tHgY4OeHLw6anmplV1pQ8qwoZrKs14ctu3VRU7T3KlAqXcS9S54QhTL5UAW18AvM+ETc8DZM1+poFM5au4+/Iw==}
     peerDependencies:
       ethers: '>=6'
 
-  '@0xsequence/abi@2.0.17':
-    resolution: {integrity: sha512-QBWIMh4JNyXGe0xQaYnEL31mh9fo9h7LA5ysnTBVvXAjFrn9ZsFxX36J04FMwctSka1OIr0+pbzMJDlD2X0gCA==}
+  '@0xsequence/abi@2.1.3':
+    resolution: {integrity: sha512-koeVkNUc/xm4yiAA1fC89r6oe6gQHwsVNkH6bTLicw1Wl9zWxqcv3GVtdFcmdablBumM4vAySHejxSEuM4S8TA==}
 
-  '@0xsequence/account@2.0.17':
-    resolution: {integrity: sha512-ZRssTtC47q1zRjPFIefohYKjfs/6aW3tCo4mhfahiRIZz5v2vt0tmaip23aMgcM+rFhZT/+Ou0eEsTYahcXrag==}
+  '@0xsequence/account@2.1.3':
+    resolution: {integrity: sha512-6VPdLWVUv3DAEqwEEx3eTHOmaUDcCAqtf+9aZGC85kW+LUogdGVHB1QUngjJeMnGlQKSTMrL/Nnm3pEGi7eMAg==}
     peerDependencies:
       ethers: '>=6'
 
-  '@0xsequence/api@2.0.17':
-    resolution: {integrity: sha512-8cyY1TKd/VPnZxE9NmLP7JaJgq5RYOmR7LjNQ5PJLJscLvzljn+R6pCFz6PVyTgMTOJd+jsMlrO53Bv62dfK4w==}
+  '@0xsequence/api@2.1.3':
+    resolution: {integrity: sha512-UTy9fnEsWi6MQjAKdZye03eofofmTV1uzodsNQA5r7AJCyFNN9x979M6k5GGG90aam6vol0cnNMuei063xA7Og==}
 
-  '@0xsequence/auth@2.0.17':
-    resolution: {integrity: sha512-eP+9s5MCR5q0c+gWFD2hIBsarmRNT1Y2kXEj4ljBFma73KH9+6AJIZ210fMmbOSi13hy7Yv6k3u2IZ7OfcpcHw==}
+  '@0xsequence/auth@2.1.3':
+    resolution: {integrity: sha512-ogG/5EhVbJg0dzRKtbeqAJPtkNXl+VNpllKq19WxyacsFR/jWquFXKjCJ2S+xne8TckW28i3QsmUZujwGoJYsw==}
     peerDependencies:
       ethers: '>=6'
 
-  '@0xsequence/core@2.0.17':
-    resolution: {integrity: sha512-jDmfWk1By3UpcTPJ6S7X48DiG/k+qow0VXnxnbKGoKr/l441X9yRT+7sJunmuEJ+MhzQSbouDjxs8TyGFbaVZA==}
+  '@0xsequence/core@2.1.3':
+    resolution: {integrity: sha512-GA5dl0tEPNywQpqKjhX9LiKJqFwc8WFnN6WD8QeFL57lQS6akMyZUHw9miCLeGTyzaMX0SiFTeQM/ztSbMEXdQ==}
     peerDependencies:
       ethers: '>=6'
 
@@ -161,56 +161,64 @@ packages:
     peerDependencies:
       ethers: '>=6'
 
-  '@0xsequence/guard@2.0.17':
-    resolution: {integrity: sha512-wilpWQP12PiNh9M2ks2lklIfoTPtVNZeO7HJ8oUkMbE/r71gsol9C0IrRHEJZRaS1tHLRjwU5fo+KAIpn6h9tg==}
-
-  '@0xsequence/indexer@2.0.17':
-    resolution: {integrity: sha512-VGjTVNCrNboIOHV/lYv9XqXqEELotOACHIRkDlF6fJh87E2vlPoKkNkAa/+IWK5vcHXWdXFdtdRKw0R9d8D0hQ==}
-
-  '@0xsequence/metadata@2.0.17':
-    resolution: {integrity: sha512-xcGlhJN2V37bKeqxseBuhXRMj64vfoR5iuXtF/gfPee6zK0oAevqQoYNOqeeBo8ZqbYng9iuMURuhlOAl5W3gg==}
-
-  '@0xsequence/migration@2.0.17':
-    resolution: {integrity: sha512-qMd7KljmpU0evdgkYeg9CP80c3z8w3XEEZIsPAPzY+6RJsetp8khVlMiSrDVB30cWjxNCyMiZC9jNCOzOAWE7w==}
-
-  '@0xsequence/network@2.0.17':
-    resolution: {integrity: sha512-N2f+ia5f21oum4RG9x78tcgGMs58KZ1CGLrR3IuLJhCQL7DkrJ/QfOW1CHi0NFnkga8J2HROx7ixY3CLTZ0dOg==}
+  '@0xsequence/guard@2.1.3':
+    resolution: {integrity: sha512-urDqFiBM/S8AUfgXs5Nb95M2YyA7kXJQm4UCVMhQHtTOQz+L3XXJRfP2d68FdPkQvDkg5hfjJl1xVIq3ZsPn+g==}
     peerDependencies:
       ethers: '>=6'
 
-  '@0xsequence/provider@2.0.17':
-    resolution: {integrity: sha512-u4vFbgdTRWlTFRX/UAGTu8Hn5I6L8jFJtoSmyG9X4szwjxOc+DdjVZ5lKZ0QaFgAftTteKL2PndeM3RIT+c9yw==}
+  '@0xsequence/indexer@2.1.3':
+    resolution: {integrity: sha512-49QUo3TgecAaqNNi0n0/1AGV6c1wfNAPsYOCFFhotNJvxgVYfEBseSPx/bFN1QCYDX2v5fdMQmsWJ1iiNFKdFw==}
+
+  '@0xsequence/metadata@2.1.3':
+    resolution: {integrity: sha512-YiCsledPwUNUyqTgga8VtOqQs3JNIxiEDxZfmOdgxkbA0sU0J9c+WSxS7BXgWNAqUpkuDr8dJ0ZRJjciQ/bUYQ==}
+
+  '@0xsequence/migration@2.1.3':
+    resolution: {integrity: sha512-pdYuq1QS+XaYugeyKAhjgyKiGEyZhXneIF3s5Gpy0ljPQ1l63ilpg0Vp4yihAfjau+y6y+TwQnRlM6LMynaUeg==}
     peerDependencies:
       ethers: '>=6'
 
-  '@0xsequence/relayer@2.0.17':
-    resolution: {integrity: sha512-eJ1SNdY4SqX2y/KCbqxAxAdfCeH2ZRWYtfEtESIKbCuLDhurmeYxwfQimc6OkzDUk3K2tcv8w6sWVO8wA7eXdg==}
+  '@0xsequence/network@2.1.3':
+    resolution: {integrity: sha512-Ghtvyf1qqxzzQYOaSpKDV6c5DyfmUpSoD5Lr+u2zswTCGvgK1tSic94lzKbu2WOmUAKbsXiVDvawoFaQyaMnGQ==}
     peerDependencies:
       ethers: '>=6'
 
-  '@0xsequence/replacer@2.0.17':
-    resolution: {integrity: sha512-6uSw4X1SF361HYVjC54hLDs+7tPufl6xK4bFmh3O6V8GymZK+lT6FuCSTZeg+UgqL/yit65w6Rxi8ZL+nUMGTw==}
+  '@0xsequence/provider@2.1.3':
+    resolution: {integrity: sha512-6bxisSso9fTY9YrR8yHnn8o9dQHgFDJi1R3iFc1HtNfasCxb0TwS9wblz/v3Us+943WqC9zUM12XZTMQZ+D55Q==}
     peerDependencies:
       ethers: '>=6'
 
-  '@0xsequence/sessions@2.0.17':
-    resolution: {integrity: sha512-JeHYjmKLO2bFOFl0YDP01L7us7Syb+evcihuZRtVIoR49x2GIPcYDACNuKQfDInXtf+Vvfgm1P4/2suiCyYWJQ==}
-
-  '@0xsequence/signhub@2.0.17':
-    resolution: {integrity: sha512-WmGTGGM4nrCvk+bl/7ee7+FWJXDmcvXlpgvmqzlLkTZrawmCJ/6fp16ODo+C2R3MBSdUcEZ9gX4HL6I0rDstbw==}
-
-  '@0xsequence/utils@2.0.17':
-    resolution: {integrity: sha512-7Z5m7NGxCVnCF+p1uU+nYSBC2ezJHXDZrknue6aVzPVAK7WZB7oo8mxHTC5V/7Oov/2G6kSCebEnEOz2XrZdNg==}
+  '@0xsequence/relayer@2.1.3':
+    resolution: {integrity: sha512-8+WgbUT+ORvQwnHiegotHPLmxh/tl96VtUk0jDpEJX6iADaCpMshUqqvw4rUccV2G19jJQrhFP6DhEHTesLTBQ==}
     peerDependencies:
       ethers: '>=6'
 
-  '@0xsequence/waas@2.0.17':
-    resolution: {integrity: sha512-sW6hPItFShwOjMv+6e1qnTXvXiBsqkB6jYDfKZ4kL0xN2NFegMf6ux3aQ3FCi9I5Ql3y1h4eWGFTTgrGIj4aBA==}
+  '@0xsequence/replacer@2.1.3':
+    resolution: {integrity: sha512-QSLaHPS9P7d31Ij0pZkt1SSz43VwSXeUbGkU6JVKx3HRU/u6H9KwExAJgwcs4B1zepMSq5mXG7Rz/Ri9XK1vCw==}
     peerDependencies:
       ethers: '>=6'
 
-  '@0xsequence/wallet@2.0.17':
-    resolution: {integrity: sha512-5EQloLTWh8ti5BM/PStl1H4yfGFdABMEjZDxObZCO58DBLUoBAl5/1rWZ76QHsPzqpRYeTp2sV/r2s/jr2SnTQ==}
+  '@0xsequence/sessions@2.1.3':
+    resolution: {integrity: sha512-9pm4tSZD9uji1sH3LyRXKY7v6dmAo37pSYo8SknAQkDYggFx40TSEE5jkmD0YuqN6eL2yyypCUynqGjoO4BkVA==}
+    peerDependencies:
+      ethers: '>=6'
+
+  '@0xsequence/signhub@2.1.3':
+    resolution: {integrity: sha512-ZKLub0khcp4sN3IAZpat9MbnkLjq2M275hzv0XwDNOfHOcIESrSMWwNBqPg5ILqwR1o4JQxr0FyRoh9GG8gSjA==}
+    peerDependencies:
+      ethers: '>=6'
+
+  '@0xsequence/utils@2.1.3':
+    resolution: {integrity: sha512-ZoHq6NpAbDFSXBkwaAxJYGQC8tSwKVSuwpyLQPdVkGWZhpkbifbML+RBEMe2x57biVj1c0EqF4K3xh0sYgQQEg==}
+    peerDependencies:
+      ethers: '>=6'
+
+  '@0xsequence/waas@2.1.3':
+    resolution: {integrity: sha512-6qjqoyR3rVHrf5Vwfwu6+opPn8U9wOICfyC1Tv4NYPnrSkJF6LEaJFel0uJldxH0V0hxaYuy3h3SnKk4RfYjJw==}
+    peerDependencies:
+      ethers: '>=6'
+
+  '@0xsequence/wallet@2.1.3':
+    resolution: {integrity: sha512-oVd6LOfwdqzN8xgjd33odkGaVJ43D/NMHgLIKlpUlXnZa9d8c4fy5bA7Gujh9jWMI9qWjFP5kGImXgJ2b6/rZw==}
     peerDependencies:
       ethers: '>=6'
 
@@ -435,8 +443,8 @@ packages:
     resolution: {integrity: sha512-vwIVdXG+j+FOpkwqHRcBgHLYNL7XMkufrlaFvL9o6Ai9sJn9+PdyIL5qa0XzTZw084c+u9LOls53eoZWP/W5WQ==}
     engines: {node: '>=6.9.0'}
 
-  '@databeat/tracker@0.9.2':
-    resolution: {integrity: sha512-QcWRZh9UQzvKiP++3vArSd/ccUulbmlUsMycacnNrK4BzqKdihIZZ/YVVFs6p2fvt7X3OuwX1EuHTtESrsQ3CQ==}
+  '@databeat/tracker@0.9.3':
+    resolution: {integrity: sha512-eGsiNU/CRFujcNtUUqvBiqveCs6S6SiAhalXPDodbk74d3FzvLqHDn5k6WfOEJIhrP3CbYgfMXL0nk51s/rQsg==}
 
   '@emotion/hash@0.9.2':
     resolution: {integrity: sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==}
@@ -818,6 +826,10 @@ packages:
   '@noble/hashes@1.3.2':
     resolution: {integrity: sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==}
     engines: {node: '>= 16'}
+
+  '@noble/hashes@1.6.1':
+    resolution: {integrity: sha512-pq5D8h10hHBjyqX+cfBm0i8JUXJ0UhczFc4r74zbuT9XgewFo2E3J1cOaGtdZynILNmQ685YWGzGE1Zv6io50w==}
+    engines: {node: ^14.21.3 || >=16}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -3271,72 +3283,63 @@ packages:
 
 snapshots:
 
-  0xsequence@2.0.17(ethers@6.13.3):
+  0xsequence@2.1.3(ethers@6.13.3):
     dependencies:
-      '@0xsequence/abi': 2.0.17
-      '@0xsequence/account': 2.0.17(ethers@6.13.3)
-      '@0xsequence/api': 2.0.17
-      '@0xsequence/auth': 2.0.17(ethers@6.13.3)
-      '@0xsequence/core': 2.0.17(ethers@6.13.3)
-      '@0xsequence/guard': 2.0.17
-      '@0xsequence/indexer': 2.0.17
-      '@0xsequence/metadata': 2.0.17
-      '@0xsequence/migration': 2.0.17
-      '@0xsequence/network': 2.0.17(ethers@6.13.3)
-      '@0xsequence/provider': 2.0.17(ethers@6.13.3)
-      '@0xsequence/relayer': 2.0.17(ethers@6.13.3)
-      '@0xsequence/sessions': 2.0.17
-      '@0xsequence/signhub': 2.0.17
-      '@0xsequence/utils': 2.0.17(ethers@6.13.3)
-      '@0xsequence/wallet': 2.0.17(ethers@6.13.3)
+      '@0xsequence/abi': 2.1.3
+      '@0xsequence/account': 2.1.3(ethers@6.13.3)
+      '@0xsequence/api': 2.1.3
+      '@0xsequence/auth': 2.1.3(ethers@6.13.3)
+      '@0xsequence/core': 2.1.3(ethers@6.13.3)
+      '@0xsequence/guard': 2.1.3(ethers@6.13.3)
+      '@0xsequence/indexer': 2.1.3
+      '@0xsequence/metadata': 2.1.3
+      '@0xsequence/migration': 2.1.3(ethers@6.13.3)
+      '@0xsequence/network': 2.1.3(ethers@6.13.3)
+      '@0xsequence/provider': 2.1.3(ethers@6.13.3)
+      '@0xsequence/relayer': 2.1.3(ethers@6.13.3)
+      '@0xsequence/sessions': 2.1.3(ethers@6.13.3)
+      '@0xsequence/signhub': 2.1.3(ethers@6.13.3)
+      '@0xsequence/utils': 2.1.3(ethers@6.13.3)
+      '@0xsequence/wallet': 2.1.3(ethers@6.13.3)
       ethers: 6.13.3
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
 
-  '@0xsequence/abi@2.0.17': {}
+  '@0xsequence/abi@2.1.3': {}
 
-  '@0xsequence/account@2.0.17(ethers@6.13.3)':
+  '@0xsequence/account@2.1.3(ethers@6.13.3)':
     dependencies:
-      '@0xsequence/abi': 2.0.17
-      '@0xsequence/core': 2.0.17(ethers@6.13.3)
-      '@0xsequence/migration': 2.0.17
-      '@0xsequence/network': 2.0.17(ethers@6.13.3)
-      '@0xsequence/relayer': 2.0.17(ethers@6.13.3)
-      '@0xsequence/sessions': 2.0.17
-      '@0xsequence/utils': 2.0.17(ethers@6.13.3)
-      '@0xsequence/wallet': 2.0.17(ethers@6.13.3)
+      '@0xsequence/abi': 2.1.3
+      '@0xsequence/core': 2.1.3(ethers@6.13.3)
+      '@0xsequence/migration': 2.1.3(ethers@6.13.3)
+      '@0xsequence/network': 2.1.3(ethers@6.13.3)
+      '@0xsequence/relayer': 2.1.3(ethers@6.13.3)
+      '@0xsequence/sessions': 2.1.3(ethers@6.13.3)
+      '@0xsequence/utils': 2.1.3(ethers@6.13.3)
+      '@0xsequence/wallet': 2.1.3(ethers@6.13.3)
       ethers: 6.13.3
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
 
-  '@0xsequence/api@2.0.17': {}
+  '@0xsequence/api@2.1.3': {}
 
-  '@0xsequence/auth@2.0.17(ethers@6.13.3)':
+  '@0xsequence/auth@2.1.3(ethers@6.13.3)':
     dependencies:
-      '@0xsequence/abi': 2.0.17
-      '@0xsequence/account': 2.0.17(ethers@6.13.3)
-      '@0xsequence/api': 2.0.17
-      '@0xsequence/core': 2.0.17(ethers@6.13.3)
+      '@0xsequence/abi': 2.1.3
+      '@0xsequence/account': 2.1.3(ethers@6.13.3)
+      '@0xsequence/api': 2.1.3
+      '@0xsequence/core': 2.1.3(ethers@6.13.3)
       '@0xsequence/ethauth': 1.0.0(ethers@6.13.3)
-      '@0xsequence/indexer': 2.0.17
-      '@0xsequence/metadata': 2.0.17
-      '@0xsequence/migration': 2.0.17
-      '@0xsequence/network': 2.0.17(ethers@6.13.3)
-      '@0xsequence/sessions': 2.0.17
-      '@0xsequence/signhub': 2.0.17
-      '@0xsequence/utils': 2.0.17(ethers@6.13.3)
-      '@0xsequence/wallet': 2.0.17(ethers@6.13.3)
+      '@0xsequence/indexer': 2.1.3
+      '@0xsequence/metadata': 2.1.3
+      '@0xsequence/migration': 2.1.3(ethers@6.13.3)
+      '@0xsequence/network': 2.1.3(ethers@6.13.3)
+      '@0xsequence/sessions': 2.1.3(ethers@6.13.3)
+      '@0xsequence/signhub': 2.1.3(ethers@6.13.3)
+      '@0xsequence/utils': 2.1.3(ethers@6.13.3)
+      '@0xsequence/wallet': 2.1.3(ethers@6.13.3)
       ethers: 6.13.3
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
 
-  '@0xsequence/core@2.0.17(ethers@6.13.3)':
+  '@0xsequence/core@2.1.3(ethers@6.13.3)':
     dependencies:
-      '@0xsequence/abi': 2.0.17
-      '@0xsequence/utils': 2.0.17(ethers@6.13.3)
+      '@0xsequence/abi': 2.1.3
+      '@0xsequence/utils': 2.1.3(ethers@6.13.3)
       ethers: 6.13.3
 
   '@0xsequence/design-system@1.7.8(@types/react-dom@18.3.0)(@types/react@18.3.11)(framer-motion@11.11.7(@emotion/is-prop-valid@1.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
@@ -3367,101 +3370,86 @@ snapshots:
       ethers: 6.13.3
       js-base64: 3.7.7
 
-  '@0xsequence/guard@2.0.17':
+  '@0xsequence/guard@2.1.3(ethers@6.13.3)':
     dependencies:
-      '@0xsequence/account': 2.0.17(ethers@6.13.3)
-      '@0xsequence/core': 2.0.17(ethers@6.13.3)
-      '@0xsequence/signhub': 2.0.17
-      '@0xsequence/utils': 2.0.17(ethers@6.13.3)
-      ethers: 6.13.3
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
-  '@0xsequence/indexer@2.0.17': {}
-
-  '@0xsequence/metadata@2.0.17': {}
-
-  '@0xsequence/migration@2.0.17':
-    dependencies:
-      '@0xsequence/abi': 2.0.17
-      '@0xsequence/core': 2.0.17(ethers@6.13.3)
-      '@0xsequence/wallet': 2.0.17(ethers@6.13.3)
-      ethers: 6.13.3
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
-  '@0xsequence/network@2.0.17(ethers@6.13.3)':
-    dependencies:
-      '@0xsequence/core': 2.0.17(ethers@6.13.3)
-      '@0xsequence/indexer': 2.0.17
-      '@0xsequence/relayer': 2.0.17(ethers@6.13.3)
-      '@0xsequence/utils': 2.0.17(ethers@6.13.3)
+      '@0xsequence/account': 2.1.3(ethers@6.13.3)
+      '@0xsequence/core': 2.1.3(ethers@6.13.3)
+      '@0xsequence/signhub': 2.1.3(ethers@6.13.3)
+      '@0xsequence/utils': 2.1.3(ethers@6.13.3)
       ethers: 6.13.3
 
-  '@0xsequence/provider@2.0.17(ethers@6.13.3)':
+  '@0xsequence/indexer@2.1.3': {}
+
+  '@0xsequence/metadata@2.1.3': {}
+
+  '@0xsequence/migration@2.1.3(ethers@6.13.3)':
     dependencies:
-      '@0xsequence/abi': 2.0.17
-      '@0xsequence/account': 2.0.17(ethers@6.13.3)
-      '@0xsequence/auth': 2.0.17(ethers@6.13.3)
-      '@0xsequence/core': 2.0.17(ethers@6.13.3)
-      '@0xsequence/migration': 2.0.17
-      '@0xsequence/network': 2.0.17(ethers@6.13.3)
-      '@0xsequence/relayer': 2.0.17(ethers@6.13.3)
-      '@0xsequence/utils': 2.0.17(ethers@6.13.3)
-      '@0xsequence/wallet': 2.0.17(ethers@6.13.3)
-      '@databeat/tracker': 0.9.2
+      '@0xsequence/abi': 2.1.3
+      '@0xsequence/core': 2.1.3(ethers@6.13.3)
+      '@0xsequence/wallet': 2.1.3(ethers@6.13.3)
+      ethers: 6.13.3
+
+  '@0xsequence/network@2.1.3(ethers@6.13.3)':
+    dependencies:
+      '@0xsequence/core': 2.1.3(ethers@6.13.3)
+      '@0xsequence/indexer': 2.1.3
+      '@0xsequence/relayer': 2.1.3(ethers@6.13.3)
+      '@0xsequence/utils': 2.1.3(ethers@6.13.3)
+      ethers: 6.13.3
+
+  '@0xsequence/provider@2.1.3(ethers@6.13.3)':
+    dependencies:
+      '@0xsequence/abi': 2.1.3
+      '@0xsequence/account': 2.1.3(ethers@6.13.3)
+      '@0xsequence/auth': 2.1.3(ethers@6.13.3)
+      '@0xsequence/core': 2.1.3(ethers@6.13.3)
+      '@0xsequence/migration': 2.1.3(ethers@6.13.3)
+      '@0xsequence/network': 2.1.3(ethers@6.13.3)
+      '@0xsequence/relayer': 2.1.3(ethers@6.13.3)
+      '@0xsequence/utils': 2.1.3(ethers@6.13.3)
+      '@0xsequence/wallet': 2.1.3(ethers@6.13.3)
+      '@databeat/tracker': 0.9.3
       ethers: 6.13.3
       eventemitter2: 6.4.9
       webextension-polyfill: 0.10.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
 
-  '@0xsequence/relayer@2.0.17(ethers@6.13.3)':
+  '@0xsequence/relayer@2.1.3(ethers@6.13.3)':
     dependencies:
-      '@0xsequence/abi': 2.0.17
-      '@0xsequence/core': 2.0.17(ethers@6.13.3)
-      '@0xsequence/utils': 2.0.17(ethers@6.13.3)
+      '@0xsequence/abi': 2.1.3
+      '@0xsequence/core': 2.1.3(ethers@6.13.3)
+      '@0xsequence/utils': 2.1.3(ethers@6.13.3)
       ethers: 6.13.3
 
-  '@0xsequence/replacer@2.0.17(ethers@6.13.3)':
+  '@0xsequence/replacer@2.1.3(ethers@6.13.3)':
     dependencies:
-      '@0xsequence/abi': 2.0.17
-      '@0xsequence/core': 2.0.17(ethers@6.13.3)
+      '@0xsequence/abi': 2.1.3
+      '@0xsequence/core': 2.1.3(ethers@6.13.3)
       ethers: 6.13.3
 
-  '@0xsequence/sessions@2.0.17':
+  '@0xsequence/sessions@2.1.3(ethers@6.13.3)':
     dependencies:
-      '@0xsequence/core': 2.0.17(ethers@6.13.3)
-      '@0xsequence/migration': 2.0.17
-      '@0xsequence/replacer': 2.0.17(ethers@6.13.3)
-      '@0xsequence/utils': 2.0.17(ethers@6.13.3)
+      '@0xsequence/core': 2.1.3(ethers@6.13.3)
+      '@0xsequence/migration': 2.1.3(ethers@6.13.3)
+      '@0xsequence/replacer': 2.1.3(ethers@6.13.3)
+      '@0xsequence/utils': 2.1.3(ethers@6.13.3)
       ethers: 6.13.3
       idb: 7.1.1
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
 
-  '@0xsequence/signhub@2.0.17':
+  '@0xsequence/signhub@2.1.3(ethers@6.13.3)':
     dependencies:
-      '@0xsequence/core': 2.0.17(ethers@6.13.3)
+      '@0xsequence/core': 2.1.3(ethers@6.13.3)
       ethers: 6.13.3
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
 
-  '@0xsequence/utils@2.0.17(ethers@6.13.3)':
+  '@0xsequence/utils@2.1.3(ethers@6.13.3)':
     dependencies:
       ethers: 6.13.3
       js-base64: 3.7.7
 
-  '@0xsequence/waas@2.0.17(ethers@6.13.3)':
+  '@0xsequence/waas@2.1.3(ethers@6.13.3)':
     dependencies:
-      '@0xsequence/core': 2.0.17(ethers@6.13.3)
-      '@0xsequence/network': 2.0.17(ethers@6.13.3)
-      '@0xsequence/utils': 2.0.17(ethers@6.13.3)
+      '@0xsequence/core': 2.1.3(ethers@6.13.3)
+      '@0xsequence/network': 2.1.3(ethers@6.13.3)
+      '@0xsequence/utils': 2.1.3(ethers@6.13.3)
       '@aws-sdk/client-cognito-identity-provider': 3.668.0
       ethers: 6.13.3
       idb: 7.1.1
@@ -3470,18 +3458,15 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@0xsequence/wallet@2.0.17(ethers@6.13.3)':
+  '@0xsequence/wallet@2.1.3(ethers@6.13.3)':
     dependencies:
-      '@0xsequence/abi': 2.0.17
-      '@0xsequence/core': 2.0.17(ethers@6.13.3)
-      '@0xsequence/network': 2.0.17(ethers@6.13.3)
-      '@0xsequence/relayer': 2.0.17(ethers@6.13.3)
-      '@0xsequence/signhub': 2.0.17
-      '@0xsequence/utils': 2.0.17(ethers@6.13.3)
+      '@0xsequence/abi': 2.1.3
+      '@0xsequence/core': 2.1.3(ethers@6.13.3)
+      '@0xsequence/network': 2.1.3(ethers@6.13.3)
+      '@0xsequence/relayer': 2.1.3(ethers@6.13.3)
+      '@0xsequence/signhub': 2.1.3(ethers@6.13.3)
+      '@0xsequence/utils': 2.1.3(ethers@6.13.3)
       ethers: 6.13.3
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
 
   '@adraffy/ens-normalize@1.10.1': {}
 
@@ -4012,9 +3997,9 @@ snapshots:
       '@babel/helper-validator-identifier': 7.25.7
       to-fast-properties: 2.0.0
 
-  '@databeat/tracker@0.9.2':
+  '@databeat/tracker@0.9.3':
     dependencies:
-      '@noble/hashes': 1.3.2
+      '@noble/hashes': 1.6.1
 
   '@emotion/hash@0.9.2': {}
 
@@ -4256,6 +4241,8 @@ snapshots:
       '@noble/hashes': 1.3.2
 
   '@noble/hashes@1.3.2': {}
+
+  '@noble/hashes@1.6.1': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:

--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -1,4 +1,17 @@
-import { Box, Text, TextInput, Button, Spinner, Divider, Modal, Switch } from '@0xsequence/design-system'
+import {
+  Box,
+  Text,
+  TextInput,
+  Button,
+  Spinner,
+  Divider,
+  Modal,
+  Collapsible,
+  EmailIcon,
+  KeyIcon,
+  Toast,
+  Switch
+} from '@0xsequence/design-system'
 import { SetStateAction, useEffect, useRef, useState } from 'react'
 import { CredentialResponse, GoogleLogin, useGoogleLogin } from '@react-oauth/google'
 import AppleSignin from 'react-apple-signin-auth'
@@ -17,9 +30,14 @@ import { EmailConflictInfo } from '@0xsequence/waas'
 import { PlayFabClient } from 'playfab-sdk'
 import { LoginRequest } from './LoginRequest.tsx'
 import { getMessageFromUnknownError } from './utils/getMessageFromUnknownError.ts'
+import { useCallback } from 'react'
 
 function Login() {
   const [email, setEmail] = useState('')
+  const [playfabEmail, setPlayfabEmail] = useState('')
+  const [playfabError, setPlayfabError] = useState('')
+  const [playfabLoggingIn, setPlayfabLoggingIn] = useState(false)
+  const [playfabPassword, setPlayfabPassword] = useState('')
   const inputRef = useRef<HTMLInputElement | null>(null)
   const isEmailValid = inputRef.current?.validity.valid
   const [showEmailWarning, setEmailWarning] = useState(false)
@@ -65,6 +83,41 @@ function Login() {
       )
     }
   })
+
+  const handlePlayfabLogin = useCallback(
+    () =>
+      PlayFabClient.LoginWithEmailAddress(
+        {
+          Password: playfabPassword,
+          Email: playfabEmail
+        },
+        async (error, response) => {
+          if (error) {
+            setPlayfabError(JSON.stringify(error))
+            console.error('Error: ' + JSON.stringify(error))
+          } else if (response.data.SessionTicket) {
+            try {
+              const seqRes = await sequence.signIn(
+                {
+                  playFabTitleId: import.meta.env.VITE_PLAYFAB_TITLE_ID,
+                  playFabSessionTicket: response.data.SessionTicket
+                },
+                randomName()
+              )
+              console.log('Sequence response:', seqRes)
+              router.navigate('/')
+              setPlayfabError('')
+            } catch (e) {
+              console.error('Error: ' + getMessageFromUnknownError(e))
+              setPlayfabError(getMessageFromUnknownError(e))
+            }
+          }
+          setPlayfabLoggingIn(false)
+          setTimeout(() => setPlayfabError(''), 4000)
+        }
+      ),
+    [playfabEmail, playfabPassword]
+  )
 
   const {
     inProgress: emailAuthInProgress,
@@ -274,17 +327,48 @@ function Login() {
               <Divider background="buttonGlass" width="full" />
 
               {import.meta.env.VITE_PLAYFAB_TITLE_ID && (
-                <Box>
-                  <Box marginBottom="4">
-                    <Text variant="large" color="text100" fontWeight="bold">
-                      Playfab login
-                    </Text>
-                  </Box>
-
+                <Collapsible label="Playfab Login">
                   <Box>
                     <Button label="Login with Google (through Playfab)" onClick={handleGooglePlayfabLogin} />
                   </Box>
-                </Box>
+                  <br />
+                  <Collapsible label="Login with Playfab email/password">
+                    <Box flexDirection="row" gap="4">
+                      <TextInput
+                        leftIcon={EmailIcon}
+                        placeholder="email address"
+                        onChange={(ev: { target: { value: SetStateAction<string> } }) => setPlayfabEmail(ev.target.value)}
+                      />
+                      <TextInput
+                        leftIcon={KeyIcon}
+                        placeholder="password"
+                        type="password"
+                        onChange={(ev: { target: { value: SetStateAction<string> } }) => setPlayfabPassword(ev.target.value)}
+                        onKeyDown={(event: KeyboardEvent) => {
+                          if (event.key === 'Enter') {
+                            if (playfabLoggingIn) {
+                              return
+                            }
+                            setPlayfabLoggingIn(true)
+                            handlePlayfabLogin()
+                          }
+                        }}
+                      />
+                      <Button
+                        pending={playfabLoggingIn}
+                        label="Login"
+                        onClick={() => {
+                          if (playfabLoggingIn) {
+                            return
+                          }
+                          setPlayfabLoggingIn(true)
+                          handlePlayfabLogin()
+                        }}
+                      />
+                    </Box>
+                    {playfabError && <Toast title="Error" variant="error" isDismissible={true} description={playfabError} />}
+                  </Collapsible>
+                </Collapsible>
               )}
 
               {import.meta.env.VITE_STYTCH_PUBLIC_TOKEN && !import.meta.env.VITE_STYTCH_LEGACY_ISSUER && <StytchLogin />}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -40,7 +40,7 @@ if (targetEnv === 'dev') {
 export const sequence = new SequenceWaaS({
   network: 'polygon',
   projectAccessKey: projectAccessKey,
-  waasConfigKey: waasConfigKey,
+  waasConfigKey: waasConfigKey
 })
 
 export const router = createHashRouter([


### PR DESCRIPTION
## Summary by Sourcery

Upgrade Sequence dependencies to 2.2.4 and add PlayFab email/password login.

Enhancements:
- Add PlayFab email/password login option in the Login component.
- Improve error handling and display in PlayFab login flow.
- Update Sequence signIn method to use PlayFabTitleId and PlayFabSessionTicket from environment variables and response data respectively.
- Add collapsible sections for PlayFab and email/password login options in the Login component.
- Update Sequence initialization to use waasConfigKey from environment variables

Build:
- Upgrade 0xsequence packages from 2.0.17 to 2.2.4.
- Upgrade @databeat/tracker from 0.9.2 to 0.9.3.
- Upgrade aws-sdk client packages from 3.668.0 to 3.723.0.
- Upgrade aws-sdk core and related packages from 3.667.0 or 3.668.0 to 3.723.0.
- Upgrade @noble/hashes from 1.3.2 to 1.7.0.
- Upgrade smithy packages from various versions to 4.0.0 or 5.0.0, except for util-endpoints which is upgraded to 3.0.0 and is-array-buffer and util-buffer-from which remain at 2.2.0